### PR TITLE
feat(packages): implement package management commands and tree view

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,14 @@
     "views": {
       "ruyi": [
         {
+          "id": "ruyiPackagesView",
+          "name": "Packages",
+          "icon": "$(package)"
+        },
+        {
           "id": "ruyiNewsView",
-          "name": "News"
+          "name": "News",
+          "icon": "$(rss)"
         }
       ]
     },
@@ -69,10 +75,33 @@
         "command": "ruyi.news.read",
         "title": "Read News",
         "category": "Ruyi"
+      },
+      {
+        "command": "ruyi.packages.install",
+        "title": "Install Package",
+        "category": "Ruyi",
+        "icon": "$(cloud-download)"
+      },
+      {
+        "command": "ruyi.packages.uninstall",
+        "title": "Uninstall Package",
+        "category": "Ruyi",
+        "icon": "$(trash)"
+      },
+      {
+        "command": "ruyi.packages.refresh",
+        "title": "Refresh Package List",
+        "category": "Ruyi",
+        "icon": "$(refresh)"
       }
     ],
     "menus": {
       "view/title": [
+        {
+          "command": "ruyi.packages.refresh",
+          "when": "view == ruyiPackagesView",
+          "group": "navigation@0"
+        },
         {
           "command": "ruyi.news.showUnread",
           "when": "view == ruyiNewsView && !ruyiNews.showUnreadOnly",
@@ -84,7 +113,27 @@
           "group": "navigation@0"
         }
       ],
+      "view/item/context": [
+        {
+          "command": "ruyi.packages.install",
+          "when": "view == ruyiPackagesView && viewItem == ruyiPackage.available",
+          "group": "inline@1"
+        },
+        {
+          "command": "ruyi.packages.uninstall",
+          "when": "view == ruyiPackagesView && viewItem == ruyiPackage.installed",
+          "group": "inline@1"
+        }
+      ],
       "commandPalette": [
+        {
+          "command": "ruyi.packages.install",
+          "when": "false"
+        },
+        {
+          "command": "ruyi.packages.uninstall",
+          "when": "false"
+        },
         {
           "command": "ruyi.news.showUnread",
           "when": "false"

--- a/src/commands/packages.ts
+++ b/src/commands/packages.ts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Package Commands: install, uninstall, and refresh packages
+ *
+ * Provides user-facing commands for:
+ * - Installing packages with progress feedback
+ * - Uninstalling packages with confirmation
+ * - Refreshing the package list
+ */
+
+import * as vscode from 'vscode'
+
+import { LONG_CMD_TIMEOUT_MS } from '../common/constants'
+import { ruyiInstall, ruyiRemove } from '../common/RuyiInvoker'
+import { PackageService } from '../features/packages/PackageService'
+import { PackagesTreeProvider, VersionItem } from '../features/packages/PackagesTree'
+
+export default function registerPackagesCommands(ctx: vscode.ExtensionContext) {
+  // Initialize service and tree provider
+  const packageService = new PackageService()
+  const packagesTreeProvider = new PackagesTreeProvider(packageService)
+
+  // Register tree view
+  const packagesTreeView = vscode.window.createTreeView('ruyiPackagesView', {
+    treeDataProvider: packagesTreeProvider,
+    showCollapseAll: true,
+  })
+  ctx.subscriptions.push(packagesTreeView)
+
+  // Auto-refresh on activation
+  void packagesTreeProvider.refresh()
+
+  const installDisposable = vscode.commands.registerCommand(
+    'ruyi.packages.install',
+    async (item: VersionItem) => {
+      if (!(item instanceof VersionItem)) {
+        vscode.window.showErrorMessage('Invalid package selection.')
+        return
+      }
+
+      const packageId = item.getPackageId()
+      const packageName = item.pkg.name.split('/').pop() || item.pkg.name
+
+      const choice = await vscode.window.showInformationMessage(
+        `Install ${packageName} ${item.versionInfo.version}?`,
+        { modal: false },
+        'Install',
+        'Cancel',
+      )
+
+      if (choice !== 'Install') {
+        return
+      }
+
+      await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: `Installing ${packageName}...`,
+          cancellable: false,
+        },
+        async (progress) => {
+          progress.report({ message: 'Running ruyi install...' })
+
+          const result = await ruyiInstall([`'${packageId}'`], { timeout: LONG_CMD_TIMEOUT_MS })
+          if (result.code === 0) {
+            vscode.window.showInformationMessage(
+              `✓ Successfully installed ${packageName} ${item.versionInfo.version}`)
+
+            await packagesTreeProvider.refresh()
+          }
+          else {
+            const errorMsg = result.stderr || result.stdout || 'Unknown error'
+            vscode.window.showErrorMessage(
+              `Failed to install ${packageName}: ${errorMsg}`)
+          }
+        },
+      )
+    },
+  )
+
+  const uninstallDisposable = vscode.commands.registerCommand(
+    'ruyi.packages.uninstall',
+    async (item: VersionItem) => {
+      if (!(item instanceof VersionItem)) {
+        vscode.window.showErrorMessage('Invalid package selection.')
+        return
+      }
+
+      const packageId = item.getPackageId()
+      const packageName = item.pkg.name.split('/').pop() || item.pkg.name
+
+      const choice = await vscode.window.showWarningMessage(
+        `Uninstall ${packageName} ${item.versionInfo.version}?`,
+        { modal: false },
+        'Uninstall',
+        'Cancel',
+      )
+
+      if (choice !== 'Uninstall') {
+        return
+      }
+
+      const confirmation = await vscode.window.showWarningMessage(
+        `Are you sure you want to uninstall ${packageName} ${item.versionInfo.version}? This action cannot be undone.`,
+        { modal: false },
+        'Yes, Uninstall',
+        'Cancel',
+      )
+
+      if (confirmation !== 'Yes, Uninstall') {
+        return
+      }
+
+      await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: `Uninstalling ${packageName}...`,
+          cancellable: false,
+        },
+        async (progress) => {
+          progress.report({ message: 'Running ruyi remove...' })
+
+          const result = await ruyiRemove([`'${packageId}'`, '-y'], { timeout: LONG_CMD_TIMEOUT_MS })
+
+          if (result.code === 0) {
+            vscode.window.showInformationMessage(
+              `✓ Successfully uninstalled ${packageName} ${item.versionInfo.version}`)
+
+            await packagesTreeProvider.refresh()
+          }
+          else {
+            const errorMsg = result.stderr || result.stdout || 'Unknown error'
+            vscode.window.showErrorMessage(
+              `Failed to uninstall ${packageName}: ${errorMsg}`)
+          }
+        },
+      )
+    },
+  )
+
+  const refreshDisposable = vscode.commands.registerCommand(
+    'ruyi.packages.refresh',
+    async () => {
+      await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: 'Refreshing package list...',
+          cancellable: false,
+        },
+        async () => {
+          await packagesTreeProvider.refresh()
+        },
+      )
+    },
+  )
+
+  ctx.subscriptions.push(
+    installDisposable, uninstallDisposable, refreshDisposable)
+}

--- a/src/common/RuyiInvoker.ts
+++ b/src/common/RuyiInvoker.ts
@@ -94,7 +94,7 @@ function normalizeRuyiResult(result: RuyiResult): RuyiResult {
 // High-level wrappers for Ruyi commands
 export function ruyiList(
   args: string[] = [], options?: RuyiRunOptions): Promise<RuyiResult> {
-  return runRuyi(['list', ...args], options).then(normalizeRuyiResult)
+  return runRuyi(['--porcelain', 'list', ...args], options).then(normalizeRuyiResult)
 }
 
 export function ruyiInstall(

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -17,3 +17,13 @@ export const SHORT_CMD_TIMEOUT_MS
 export const DEFAULT_CMD_TIMEOUT_MS = 10_000 // most commands
 export const LONG_CMD_TIMEOUT_MS
   = 60_000 // long tasks (e.g. pip install/upgrade)
+
+/** Valid package categories */
+export const VALID_PACKAGE_CATEGORIES = [
+  'toolchain',
+  'source',
+  'emulator',
+  'board-image',
+  'analyzer',
+  'extra',
+] as const

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,9 @@
  *   • ruyi.news.read    (./commands/news)
  *   • ruyi.news.showAll (./commands/news)
  *   • ruyi.news.showUnread (./commands/news)
+ *   • ruyi.packages.install    (./commands/packages)
+ *   • ruyi.packages.uninstall  (./commands/packages)
+ *   • ruyi.packages.refresh    (./commands/packages)
  *
  * - Run an automatic detect on activation.
  */
@@ -18,12 +21,16 @@ import * as vscode from 'vscode'
 import registerDetectCommand from './commands/detect'
 import registerInstallCommand from './commands/installRuyi'
 import registerNewsCommands from './commands/news'
+import registerPackagesCommands from './commands/packages'
 
 export function activate(context: vscode.ExtensionContext) {
+  // Register commands
   registerDetectCommand(context)
   registerInstallCommand(context)
   registerNewsCommands(context)
+  registerPackagesCommands(context)
 
+  // Run initial detection
   setImmediate(() => {
     void vscode.commands.executeCommand('ruyi.detect')
   })

--- a/src/features/packages/PackageService.ts
+++ b/src/features/packages/PackageService.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * PackageService
+ *
+ * Provides package listing, parsing, and installation status tracking.
+ *
+ * Features:
+ * - Retrieves all available packages via `ruyi list`
+ * - Parses package information including categories, versions, and metadata
+ * - Tracks installation status by querying `ruyi list -- porcelain --installed`
+ * - Caches results to minimize CLI calls
+ */
+
+import { DEFAULT_CMD_TIMEOUT_MS, VALID_PACKAGE_CATEGORIES } from '../../common/constants'
+import { ruyiList } from '../../common/RuyiInvoker'
+
+export type PackageCategory = typeof VALID_PACKAGE_CATEGORIES[number] | 'unknown'
+
+export interface RuyiPackageVersion {
+  version: string
+  isLatest: boolean
+  isPrerelease: boolean
+  isLatestPrerelease: boolean
+  isInstalled: boolean
+  isBinaryAvailable: boolean
+  slug?: string
+}
+
+export interface RuyiPackage {
+  name: string
+  category: PackageCategory
+  versions: RuyiPackageVersion[]
+}
+
+/**
+ * NDJSON output type from `ruyi list --porcelain`
+ */
+interface RuyiPorcelainPackageOutput {
+  ty: string
+  category: string
+  name: string
+  vers: Array<{
+    semver: string
+    remarks: string[]
+    is_installed: boolean
+    is_downloaded: boolean
+  }>
+}
+
+export class PackageService {
+  private packages: RuyiPackage[] = []
+
+  /**
+   * Get all available packages and cache the results.
+   * @param forceRefresh If true, force refresh data from CLI.
+   */
+  public async getPackages(forceRefresh: boolean = false):
+  Promise<RuyiPackage[]> {
+    if (!forceRefresh && this.packages.length > 0) {
+      return this.packages
+    }
+
+    try {
+      const listResult = await ruyiList(['--name-contains', '\'\''], { timeout: DEFAULT_CMD_TIMEOUT_MS })
+      if (listResult.code !== 0) {
+        console.error('Failed to list packages:', listResult.stderr)
+        return []
+      }
+
+      this.packages = this.parsePorcelainListOutput(listResult.stdout)
+      return this.packages
+    }
+    catch (error) {
+      console.error('Error fetching packages:', error)
+      return []
+    }
+  }
+
+  /**
+   * Parse the NDJSON output of `ruyi --porcelain list`.
+   * Each line is a separate JSON object.
+   */
+  private parsePorcelainListOutput(output: string): RuyiPackage[] {
+    return output
+      .split('\n')
+      .filter(line => line.trim())
+      .map((line) => {
+        try {
+          return JSON.parse(line) as RuyiPorcelainPackageOutput
+        }
+        catch {
+          // Skip non-JSON lines (e.g., log messages)
+          return null
+        }
+      })
+      .filter(
+        (item): item is RuyiPorcelainPackageOutput =>
+          item !== null && item.ty === 'pkglistoutput-v1',
+      )
+
+      // Exclude 'source' category
+      .filter(item => item.category !== 'source')
+      .map((item) => {
+        const category = this.normalizeCategory(item.category)
+        const versions: RuyiPackageVersion[] = item.vers.map((v) => {
+          const isPrerelease = v.semver.includes('-')
+          const isLatest = v.remarks.includes('latest')
+          const isLatestPrerelease = v.remarks.includes('latest-prerelease')
+          const slugRemark = v.remarks.find(r => r.startsWith('slug:'))
+
+          return {
+            version: v.semver,
+            isInstalled: v.is_installed,
+            isLatest,
+            isPrerelease,
+            isLatestPrerelease,
+            isBinaryAvailable: !v.remarks.includes('no-binary-for-current-host'),
+            slug: slugRemark ? slugRemark.substring(5).trim() : undefined,
+          }
+        })
+
+        return {
+          name: `${item.category}/${item.name}`,
+          category,
+          versions,
+        }
+      })
+  }
+
+  /**
+   * Normalize category string to PackageCategory type.
+   */
+  private normalizeCategory(category: string): PackageCategory {
+    if ((VALID_PACKAGE_CATEGORIES as readonly string[]).includes(category)) {
+      return category as PackageCategory
+    }
+
+    return 'unknown'
+  }
+}

--- a/src/features/packages/PackagesTree.ts
+++ b/src/features/packages/PackagesTree.ts
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * PackagesTreeProvider
+ *
+ * Displays Ruyi packages in a tree view with the following hierarchy:
+ * - Category (toolchain, source, emulator, etc.)
+ *   - Package (e.g., llvm-plct)
+ *     - Version (e.g., 17.0.6-ruyi.20240511)
+ *
+ * Each version item shows:
+ * - Installation status (installed/available)
+ * - Version tags (latest, prerelease, no binary)
+ * - Context menu for install/uninstall actions
+ */
+
+import * as vscode from 'vscode'
+
+import { RuyiPackage, RuyiPackageVersion, PackageService } from './PackageService'
+
+// Define tree node types
+type TreeElement = PackageCategoryItem | PackageItem | VersionItem
+
+export class PackagesTreeProvider implements
+    vscode.TreeDataProvider<TreeElement> {
+  private _onDidChangeTreeData = new vscode.EventEmitter<void>()
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event
+
+  constructor(private packageService: PackageService) {}
+
+  /**
+   * Refresh the tree view and force data refresh.
+   */
+  async refresh(): Promise<void> {
+    try {
+      await this.packageService.getPackages(true)
+    }
+    catch (err) {
+      console.error('Failed to refresh packages:', err)
+    }
+    finally {
+      this._onDidChangeTreeData.fire()
+    }
+  }
+
+  getTreeItem(element: TreeElement): vscode.TreeItem {
+    return element
+  }
+
+  async getChildren(element?: TreeElement): Promise<TreeElement[]> {
+    if (!element) {
+      // Root node: show categories
+      const packages = await this.packageService.getPackages()
+      if (packages.length === 0) {
+        return []
+      }
+
+      const categories = new Set(packages.map(p => p.category))
+      return Array.from(categories).sort().map(c => new PackageCategoryItem(c))
+    }
+
+    if (element instanceof PackageCategoryItem) {
+      // Category node: display the packages under this category
+      const packages = await this.packageService.getPackages()
+      return packages
+        .filter(p => p.category === element.category)
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map(p => new PackageItem(p))
+    }
+
+    if (element instanceof PackageItem) {
+      // Package node: show versions
+      return element.pkg.versions.map(v => new VersionItem(element.pkg, v))
+    }
+
+    return []
+  }
+}
+
+/**
+ * Category node
+ */
+class PackageCategoryItem extends vscode.TreeItem {
+  constructor(public readonly category: string) {
+    super(category, vscode.TreeItemCollapsibleState.Collapsed)
+    this.iconPath = new vscode.ThemeIcon('folder')
+    this.contextValue = 'ruyiPackage.category'
+  }
+}
+
+/**
+ * Package node
+ */
+class PackageItem extends vscode.TreeItem {
+  constructor(public readonly pkg: RuyiPackage) {
+    const displayName = pkg.name.split('/').slice(1).join('/') || pkg.name
+    super(displayName, vscode.TreeItemCollapsibleState.Collapsed)
+
+    const installedCount
+      = pkg.versions.filter(v => v.isInstalled).length
+    if (installedCount > 0) {
+      this.description = `(${installedCount}/${pkg.versions.length} installed)`
+    }
+    else {
+      this.description = `(${pkg.versions.length} versions)`
+    }
+
+    this.iconPath = new vscode.ThemeIcon('package')
+    this.contextValue = 'ruyiPackage.package'
+    this.tooltip = pkg.name
+  }
+}
+
+/**
+ * Version node
+ */
+export class VersionItem extends vscode.TreeItem {
+  constructor(
+    public readonly pkg: RuyiPackage,
+    public readonly versionInfo: RuyiPackageVersion) {
+    super(versionInfo.version, vscode.TreeItemCollapsibleState.None)
+
+    // Set different icons and context menus according to the version status
+    this.description = this.buildDescription()
+    this.tooltip = this.buildTooltip()
+
+    if (versionInfo.isInstalled) {
+      this.iconPath = new vscode.ThemeIcon('check', new vscode.ThemeColor('testing.iconPassed'))
+      this.contextValue = 'ruyiPackage.installed'
+    }
+    else if (!versionInfo.isBinaryAvailable) {
+      this.iconPath = new vscode.ThemeIcon('warning', new vscode.ThemeColor('problemsWarningIcon.foreground'))
+      this.contextValue = 'ruyiPackage.unavailable'
+    }
+    else {
+      this.iconPath = new vscode.ThemeIcon('cloud-download')
+      this.contextValue = 'ruyiPackage.available'
+    }
+  }
+
+  private buildDescription(): string {
+    const tags: string[] = []
+    if (this.versionInfo.isLatest) {
+      tags.push('latest')
+    }
+    if (this.versionInfo.isPrerelease) {
+      tags.push('prerelease')
+    }
+    if (this.versionInfo.isLatestPrerelease) {
+      tags.push('latest-prerelease')
+    }
+    if (!this.versionInfo.isBinaryAvailable) {
+      tags.push('no binary')
+    }
+    if (this.versionInfo.slug) {
+      tags.push(`slug: ${this.versionInfo.slug}`)
+    }
+    return tags.join(', ')
+  }
+
+  private buildTooltip(): string {
+    let tooltip = `${this.pkg.name}@${this.versionInfo.version}\n`
+
+    if (this.versionInfo.isInstalled) {
+      tooltip += '✓ Installed\n'
+    }
+    if (this.versionInfo.isLatest) {
+      tooltip += '⭐ Latest version\n'
+    }
+    if (this.versionInfo.isPrerelease) {
+      tooltip += '🚧 Prerelease version\n'
+    }
+    if (!this.versionInfo.isBinaryAvailable) {
+      tooltip += '⚠️ No binary available for current platform\n'
+    }
+
+    return tooltip.trim()
+  }
+
+  /**
+   * Get the unique package identifier for install/uninstall commands.
+   */
+  getPackageId(): string {
+    return `${this.pkg.name}(${this.versionInfo.version})`
+  }
+}


### PR DESCRIPTION
This pull request introduces a new package management feature to the extension, allowing users to view, install, uninstall, and refresh Ruyi packages directly from the VS Code UI. The main changes include the addition of a Packages tree view, new commands for package operations, and supporting services for package data retrieval and display.

**New Package Management Feature**

* Added a new "Packages" tree view to the extension sidebar, with distinct icons for packages and news.
* Registered new commands: `ruyi.packages.install`, `ruyi.packages.uninstall`, and `ruyi.packages.refresh`, each with appropriate icons and integration into menus and context menus for the tree view. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R78-R104) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R116-R136)
* Implemented the package command handlers in `src/commands/packages.ts`, enabling install, uninstall (with confirmation), and refresh actions with progress feedback and error handling.

**Supporting Package Data and Tree View**

* Introduced the `PackageService` class for fetching, parsing, and caching package data via the Ruyi CLI, including version and installation status parsing.
* Added the `PackagesTreeProvider` and related tree item classes to render packages by category, package, and version, with context-sensitive icons and tooltips reflecting installation and availability status.

**Supporting Constants and Integration**

* Defined valid package categories in `src/common/constants.ts` for consistent categorization.
* Updated the Ruyi CLI invocation to use the `--porcelain` flag for structured output in package listing.
* Registered the new package commands and tree view in the extension activation flow. [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R12-R14) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R24-R33)