### PR TITLE
feat: improve Ruyi detection and installation

### DIFF
--- a/src/commands/detect.ts
+++ b/src/commands/detect.ts
@@ -6,23 +6,31 @@
 
 import * as vscode from 'vscode'
 
-import { ruyiVersion } from '../common/RuyiInvoker'
+import { ruyiVersion, resolveRuyi } from '../common/RuyiInvoker'
 
 export default function registerDetectCommand(context: vscode.ExtensionContext) {
   const disposable = vscode.commands.registerCommand('ruyi.detect', async () => {
-    const version = await ruyiVersion()
-    if (version) {
-      vscode.window.showInformationMessage(`Ruyi detected: ${version}`)
+    const ruyiPath = await resolveRuyi()
+    if (!ruyiPath) {
+      const choice = await vscode.window.showErrorMessage(
+        'Ruyi not found.',
+        'Install Ruyi',
+        'Cancel',
+      )
+      if (choice === 'Install Ruyi') {
+        vscode.commands.executeCommand('ruyi.install')
+      }
       return
     }
 
-    const choice = await vscode.window.showErrorMessage(
-      'Ruyi not found.',
-      'Install Ruyi',
-      'Cancel',
-    )
-    if (choice === 'Install Ruyi') {
-      vscode.commands.executeCommand('ruyi.install')
+    const version = await ruyiVersion()
+    if (version) {
+      vscode.window.showInformationMessage(`Ruyi detected: ${version} (${ruyiPath})`)
+    }
+    else {
+      vscode.window.showWarningMessage(
+        `Ruyi found at ${ruyiPath} but version check failed. Please check your installation.`,
+      )
     }
   })
   context.subscriptions.push(disposable)


### PR DESCRIPTION
This change enables the extension to detect and run ruyi when it is installed via pipx. Previously, the extension failed to find ruyi for users who used pipx, which blocked basic features like version detection and package operations.