### PR TITLE
feat(news): add keyword search and filtering

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,18 @@
         "category": "Ruyi"
       },
       {
+        "command": "ruyi.news.search",
+        "title": "Search News",
+        "category": "Ruyi",
+        "icon": "$(search)"
+      },
+      {
+        "command": "ruyi.news.clearSearch",
+        "title": "Clear Search",
+        "category": "Ruyi",
+        "icon": "$(clear-all)"
+      },
+      {
         "command": "ruyi.packages.install",
         "title": "Install Package",
         "category": "Ruyi",
@@ -111,6 +123,16 @@
           "command": "ruyi.news.showAll",
           "when": "view == ruyiNewsView && ruyiNews.showUnreadOnly",
           "group": "navigation@0"
+         },
+        {
+          "command": "ruyi.news.search",
+          "when": "view == ruyiNewsView",
+          "group": "navigation@1"
+        },
+        {
+          "command": "ruyi.news.clearSearch",
+          "when": "view == ruyiNewsView",
+          "group": "navigation@1"
         }
       ],
       "view/item/context": [

--- a/src/commands/news.ts
+++ b/src/commands/news.ts
@@ -49,5 +49,21 @@ export default function registerNewsCommands(ctx: vscode.ExtensionContext) {
   const showAllCmd = vscode.commands.registerCommand(
     'ruyi.news.showAll', () => provider.setFilterUnreadOnly(false))
 
-  ctx.subscriptions.push(view, readCmd, showUnreadCmd, showAllCmd)
+  const searchCmd = vscode.commands.registerCommand(
+    'ruyi.news.search', async () => {
+      const query = await vscode.window.showInputBox({
+        prompt: 'Search news by title, date, or ID',
+        placeHolder: 'Enter search term...',
+        value: provider.getSearchQuery(),
+        ignoreFocusOut: true,
+      })
+      if (query !== undefined) {
+        provider.setSearchQuery(query)
+      }
+    })
+
+  const clearSearchCmd = vscode.commands.registerCommand(
+    'ruyi.news.clearSearch', () => provider.setSearchQuery(''))
+
+  ctx.subscriptions.push(view, readCmd, showUnreadCmd, showAllCmd, searchCmd, clearSearchCmd)
 }


### PR DESCRIPTION
- Add search functionality to NewsTree with multi-field matching
- Support search by title, date, and ID with case-insensitive partial matching
- Add search/clear commands with UI integration in news view
- Display user-friendly messages for empty search results