### PR TITLE
feat: Add Extract RuyiSDK Package command to explorer context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,11 @@
         "command": "ruyi.venv.switch",
         "title": "Activate, Deactivate or Switch Ruyi Virtual Environments",
         "category": "Ruyi"
+      },
+      {
+        "command": "ruyi.extract",
+        "title": "Extract RuyiSDK Package",
+        "category": "Ruyi"
       }
     ],
     "menus": {
@@ -141,6 +146,12 @@
         {
           "command": "ruyi.packages.uninstall",
           "when": "false"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "ruyi.extract",
+          "group": "navigation"
         }
       ]
     }

--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Extract Command: Extract RuyiSDK Package from source
+ *
+ * Provides user-facing command for:
+ * - Listing all available source packages
+ * - Letting user select a package to extract
+ * - Extracting the selected package to the current directory
+ */
+
+import * as path from 'path'
+import * as vscode from 'vscode'
+
+import ruyi from '../common/ruyi'
+
+/**
+ * Parse the NDJSON output of `ruyi --porcelain list` to get source packages.
+ * Each line is a separate JSON object.
+ */
+interface RuyiPorcelainPackageOutput {
+  ty: string
+  category: string
+  name: string
+  vers: Array<{
+    semver: string
+    remarks: string[]
+    is_installed: boolean
+    is_downloaded: boolean
+  }>
+}
+
+function parseSourcePackages(output: string): string[] {
+  const packages: string[] = []
+  const seen = new Set<string>()
+
+  output
+    .split('\n')
+    .filter(line => line.trim())
+    .forEach((line) => {
+      try {
+        const item = JSON.parse(line) as RuyiPorcelainPackageOutput
+        if (item.ty === 'pkglistoutput-v1' && item.category === 'source') {
+          const packageName = `${item.category}/${item.name}`
+          if (!seen.has(packageName)) {
+            packages.push(packageName)
+            seen.add(packageName)
+          }
+        }
+      }
+      catch {
+        // Skip non-JSON lines (e.g., log messages)
+      }
+    })
+
+  return packages.sort()
+}
+
+async function getTargetDirectory(uri?: vscode.Uri): Promise<string> {
+  if (uri) {
+    const stat = await vscode.workspace.fs.stat(uri)
+    if (stat.type === vscode.FileType.Directory) {
+      return uri.fsPath
+    }
+    return path.dirname(uri.fsPath)
+  }
+
+  const workspaceFolder = vscode.workspace.workspaceFolders?.[0]
+  if (!workspaceFolder) {
+    throw new Error('Please open a workspace folder first')
+  }
+  return workspaceFolder.uri.fsPath
+}
+
+async function fetchSourcePackages(): Promise<string[]> {
+  const listResult = await ruyi.list({ nameContains: '' })
+
+  if (listResult.code !== 0) {
+    throw new Error(`Failed to fetch package list: ${listResult.stderr}`)
+  }
+
+  const sourcePackages = parseSourcePackages(listResult.stdout)
+
+  if (sourcePackages.length === 0) {
+    throw new Error('No available source packages found')
+  }
+
+  return sourcePackages
+}
+
+async function extractSelectedPackage(
+  packageName: string,
+  targetDir: string,
+): Promise<void> {
+  const extractResult = await ruyi.cwd(targetDir).extract(packageName, {
+    extractWithoutSubdir: true,
+  })
+
+  if (extractResult.code !== 0) {
+    throw new Error(
+      `Failed to extract: ${extractResult.stderr || extractResult.stdout}`,
+    )
+  }
+}
+
+/**
+ * Extract RuyiSDK Package command handler
+ * @param uri - The URI of the folder where the user right-clicked
+ */
+async function extractPackage(uri?: vscode.Uri): Promise<void> {
+  try {
+    const targetDir = await getTargetDirectory(uri)
+
+    const sourcePackages = await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: 'Fetching available source packages...',
+        cancellable: false,
+      },
+      async () => fetchSourcePackages(),
+    )
+
+    const selectedPackage = await vscode.window.showQuickPick(sourcePackages, {
+      placeHolder: 'Select a package to extract',
+      title: 'Extract RuyiSDK Package',
+    })
+
+    if (!selectedPackage) {
+      return
+    }
+
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: `Extracting ${selectedPackage}...`,
+        cancellable: false,
+      },
+      async () => extractSelectedPackage(selectedPackage, targetDir),
+    )
+
+    await vscode.window.showInformationMessage(
+      `Successfully extracted ${selectedPackage} to ${targetDir}`,
+    )
+  }
+  catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error)
+
+    if (errorMessage.includes('No available source packages found')) {
+      await vscode.window.showInformationMessage(errorMessage)
+    }
+    else {
+      await vscode.window.showErrorMessage(
+        `Error occurred during extraction: ${errorMessage}`,
+      )
+    }
+  }
+}
+
+export default function registerExtractCommand(ctx: vscode.ExtensionContext) {
+  const disposable = vscode.commands.registerCommand(
+    'ruyi.extract',
+    extractPackage,
+  )
+  ctx.subscriptions.push(disposable)
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@
  *   • ruyi.packages.install    (./commands/packages)
  *   • ruyi.packages.uninstall  (./commands/packages)
  *   • ruyi.packages.refresh    (./commands/packages)
+ *   • ruyi.extract      (./commands/extract)
  *   • ruyi.venv.detect  (./commands/venv/detect)
  *   • ruyi.venv.create  (./commands/venv/create)
  *   • ruyi.venv.clean   (./commands/venv/clean)
@@ -25,6 +26,7 @@
 import * as vscode from 'vscode'
 
 import registerDetectCommand from './commands/detect'
+import registerExtractCommand from './commands/extract'
 import registerHomeCommand from './commands/home'
 import registerInstallCommand from './commands/installRuyi'
 import registerNewsCommands from './commands/news'
@@ -38,6 +40,7 @@ import registerSwitchFromVenvsCommand from './commands/venv/switch'
 export function activate(context: vscode.ExtensionContext) {
   // Register commands
   registerDetectCommand(context)
+  registerExtractCommand(context)
   registerHomeCommand(context)
   registerInstallCommand(context)
   registerNewsCommands(context)


### PR DESCRIPTION
Add command to extract source packages from explorer context menu. Lists available source packages, allows user selection, and extracts to the current directory using `ruyi extract --extract-without-subdir`.

- Add extract.ts command module
- Register ruyi.extract command and explorer context menu entry
- Include error handling and progress indicators

## Summary by Sourcery

Introduce a new "Extract RuyiSDK Package" command in the VS Code explorer context menu to list available source packages and extract the selected one into the current directory.

New Features:
- Register ruyi.extract command and add it to the explorer context menu
- Implement interactive flow to fetch source packages, prompt user selection, and run extraction without subdirectories

Enhancements:
- Display progress notifications for fetching packages and extraction
- Show informative success and error messages during extraction