### PR TITLE
refactor: extract common parseNDJSON utility to eliminate duplication

### DIFF
--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -33,3 +33,39 @@ export function getWorkspaceFolderPath(): string {
 export function fullKey(key: ConfigKey): `ruyi.${string}` {
   return `ruyi.${key}`
 }
+
+/**
+ * Parse NDJSON (Newline Delimited JSON) output.
+ *
+ * This is a common pattern for parsing ruyi CLI output with --porcelain flag.
+ * Each line is a separate JSON object. Invalid lines are skipped silently.
+ *
+ * @param output The NDJSON string to parse
+ * @returns Array of parsed JSON objects (null for invalid lines are filtered out)
+ *
+ * @example
+ * ```typescript
+ * interface Package {
+ *   ty: string
+ *   name: string
+ * }
+ *
+ * const items = parseNDJSON<Package>(output)
+ *   .filter(item => item.ty === 'pkglistoutput-v1')
+ *   .map(item => item.name)
+ * ```
+ */
+export function parseNDJSON<T>(output: string): T[] {
+  return output
+    .split('\n')
+    .map((line) => {
+      try {
+        return JSON.parse(line)
+      }
+      catch {
+        // Skip non-JSON lines
+        return null
+      }
+    })
+    .filter(item => item !== null)
+}

--- a/src/features/packages/PackageService.ts
+++ b/src/features/packages/PackageService.ts
@@ -12,6 +12,7 @@
  */
 
 import { VALID_PACKAGE_CATEGORIES } from '../../common/constants'
+import { parseNDJSON } from '../../common/helpers'
 import ruyi from '../../common/ruyi'
 
 export type PackageCategory = typeof VALID_PACKAGE_CATEGORIES[number] | 'unknown'
@@ -81,23 +82,8 @@ export class PackageService {
    * Each line is a separate JSON object.
    */
   private parsePorcelainListOutput(output: string): RuyiPackage[] {
-    return output
-      .split('\n')
-      .filter(line => line.trim())
-      .map((line) => {
-        try {
-          return JSON.parse(line) as RuyiPorcelainPackageOutput
-        }
-        catch {
-          // Skip non-JSON lines (e.g., log messages)
-          return null
-        }
-      })
-      .filter(
-        (item): item is RuyiPorcelainPackageOutput =>
-          item !== null && item.ty === 'pkglistoutput-v1',
-      )
-
+    return parseNDJSON<RuyiPorcelainPackageOutput>(output)
+      .filter(item => item.ty === 'pkglistoutput-v1')
       // Exclude 'source' category
       .filter(item => item.category !== 'source')
       .map((item) => {


### PR DESCRIPTION
## Summary by Sourcery

Extract common parseNDJSON utility and refactor existing parsers to use it

Enhancements:
- Add parseNDJSON helper for parsing newline-delimited JSON
- Update extract command to use parseNDJSON and deduplicate package list
- Refactor PackageService porcelain parser to leverage parseNDJSON and filter outputs