### PR TITLE
refactor: introduce logger class and replace console

### DIFF
--- a/src/commands/detect.ts
+++ b/src/commands/detect.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode'
 
 import * as semver from 'semver'
 
+import { logger } from '../common/logger.js'
 import ruyi, { resolveRuyi } from '../common/ruyi'
 import { configuration } from '../features/configuration/ConfigurationService'
 import { promptForTelemetryConfiguration } from '../features/telemetry/TelemetryService'
@@ -16,11 +17,11 @@ interface GitHubRelease {
   tag_name: string
 }
 
-async function checkRuyiUpdate(currentVersion: string) {
+async function checkRuyiUpdate(currentVersion: string): Promise<void> {
   try {
     const coerced = semver.coerce(currentVersion)
     if (!coerced) {
-      console.warn(`Unable to parse version from: ${currentVersion}`)
+      logger.warn(`Unable to parse version from: ${currentVersion}`)
       return
     }
 
@@ -30,7 +31,7 @@ async function checkRuyiUpdate(currentVersion: string) {
       },
     })
     if (!response.ok) {
-      console.warn(`Failed to fetch latest Ruyi release: ${response.statusText}`)
+      logger.warn(`Failed to fetch latest Ruyi release: ${response.statusText}`)
       return
     }
 
@@ -68,7 +69,7 @@ async function checkRuyiUpdate(currentVersion: string) {
     }
   }
   catch (err) {
-    console.error('Failed to check for Ruyi updates:', err)
+    logger.error('Failed to check for Ruyi updates:', err)
   }
 }
 
@@ -99,7 +100,7 @@ export default function registerDetectCommand(context: vscode.ExtensionContext) 
       // Check for updates only if enabled in configuration
       if (configuration.checkForUpdates) {
         checkRuyiUpdate(version).catch((err) => {
-          console.error('Update check failed:', err)
+          logger.error('Update check failed:', err)
         })
       }
     }

--- a/src/commands/installRuyi.ts
+++ b/src/commands/installRuyi.ts
@@ -16,6 +16,7 @@ import type { ExecException } from 'node:child_process'
 import * as util from 'util'
 import * as vscode from 'vscode'
 
+import { logger } from '../common/logger.js'
 import ruyi, { resolveRuyi } from '../common/ruyi'
 import { promptForTelemetryConfiguration } from '../features/telemetry/TelemetryService'
 
@@ -33,7 +34,7 @@ async function showInstallSuccess(method: string, version: string): Promise<void
 }
 
 async function showInstallError(method: string, errorMessage: string, continueMessage?: string): Promise<void> {
-  console.log(`[RuyiSDK] ${method} install failed: ${errorMessage}`)
+  logger.log(`${method} install failed: ${errorMessage}`)
 
   const message = continueMessage
     ? `${method} installation failed: ${errorMessage}. ${continueMessage}`

--- a/src/commands/news.ts
+++ b/src/commands/news.ts
@@ -8,6 +8,7 @@
 
 import * as vscode from 'vscode'
 
+import { logger } from '../common/logger.js'
 import NewsCards from '../features/news/NewsCards'
 import NewsService from '../features/news/NewsService'
 
@@ -17,7 +18,7 @@ export default function registerNewsCommands(ctx: vscode.ExtensionContext) {
 
   // Initialize news service
   svc.initialize().catch((err: unknown) =>
-    console.warn('Failed to initialize news service:', err),
+    logger.warn('Failed to initialize news service:', err),
   )
 
   // Note: Tree view is removed, only cards view is available

--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -17,7 +17,7 @@ import { ConfigKey } from './constants'
 export function getWorkspaceFolderPath(): string {
   const workspaceFolder = vscode.workspace.workspaceFolders?.[0]
   if (!workspaceFolder) {
-    throw `Exception: No workspace folder is open in VSCode. 
+    throw `Exception: No workspace folder is open in VSCode.
       We need a workspace folder to run the command in context.`
   }
   const workspacePath = workspaceFolder.uri.fsPath

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -1,0 +1,100 @@
+import * as vscode from 'vscode'
+
+/**
+ * Logger class that wraps VS Code's LogOutputChannel for console-like logging.
+ * Provides similar methods to console (log, info, warn, error, debug).
+ * Uses VS Code's native log levels for proper formatting.
+ */
+
+export class Logger {
+  static #outputChannel: vscode.LogOutputChannel | null = null
+
+  /**
+   * Initialize the logger with a LogOutputChannel.
+   * Should be called once during extension activation.
+   */
+  static initialize(name: string = 'RuyiSDK'): void {
+    if (!this.#outputChannel) {
+      this.#outputChannel = vscode.window.createOutputChannel(name, { log: true })
+    }
+  }
+
+  /**
+   * Get the LogOutputChannel instance.
+   * Creates one if it doesn't exist.
+   */
+  static #getChannel(): vscode.LogOutputChannel {
+    if (!this.#outputChannel) {
+      this.initialize()
+    }
+    return this.#outputChannel!
+  }
+
+  /**
+   * Log a trace message (similar to console.trace)
+   */
+  static trace(message: string, ...args: unknown[]): void {
+    this.#getChannel().trace(message, ...args)
+  }
+
+  /**
+   * Log a debug message (similar to console.debug)
+   */
+  static debug(message: string, ...args: unknown[]): void {
+    this.#getChannel().debug(message, ...args)
+  }
+
+  /**
+   * Log an info message (similar to console.info)
+   */
+  static info(message: string, ...args: unknown[]): void {
+    this.#getChannel().info(message, ...args)
+  }
+
+  /**
+   * Log a message (similar to console.log)
+   */
+  static log(message: string, ...args: unknown[]): void {
+    this.info(message, ...args)
+  }
+
+  /**
+   * Log a warning message (similar to console.warn)
+   */
+  static warn(message: string, ...args: unknown[]): void {
+    this.#getChannel().warn(message, ...args)
+  }
+
+  /**
+   * Log an error message (similar to console.error)
+   */
+  static error(message: string, ...args: unknown[]): void {
+    this.#getChannel().error(message, ...args)
+  }
+
+  /**
+   * Show the output channel (similar to opening DevTools console)
+   */
+  static show(preserveFocus: boolean = true): void {
+    this.#getChannel().show(preserveFocus)
+  }
+
+  /**
+   * Clear the output channel (similar to console.clear)
+   */
+  static clear(): void {
+    this.#getChannel().clear()
+  }
+
+  /**
+   * Dispose the output channel
+   */
+  static dispose(): void {
+    if (this.#outputChannel) {
+      this.#outputChannel.dispose()
+      this.#outputChannel = null
+    }
+  }
+}
+
+export { Logger as logger }

--- a/src/common/ruyi.ts
+++ b/src/common/ruyi.ts
@@ -14,6 +14,7 @@ import * as path from 'path'
 import { configuration } from '../features/configuration/ConfigurationService'
 
 import { getWorkspaceFolderPath } from './helpers'
+import { logger } from './logger'
 
 // ============================================================================
 // Types
@@ -97,7 +98,7 @@ export async function resolveRuyi(): Promise<string | null> {
       return configPath
     }
     else {
-      console.warn(`Configured Ruyi path does not exist: ${configPath}`)
+      logger.warn(`Configured Ruyi path does not exist: ${configPath}`)
     }
   }
 
@@ -244,7 +245,7 @@ export async function runRuyi(
  *   - Chained: await Ruyi.cwd('/path').timeout(3000).install('pkg')
  */
 export class Ruyi {
-  constructor(private options: RuyiRunOptions = {}) {}
+  constructor(private options: RuyiRunOptions = {}) { }
 
   // ============================================================================
   // Builder Methods

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,6 +36,7 @@ import registerCreateNewVenvCommand from './commands/venv/create'
 import registerDetectAllVenvsCommand from './commands/venv/detect'
 import registerTerminalHandlerCommand from './commands/venv/manageTerminal'
 import registerSwitchFromVenvsCommand from './commands/venv/switch'
+import { logger } from './common/logger'
 import { configuration } from './features/configuration/ConfigurationService'
 
 export function activate(context: vscode.ExtensionContext) {
@@ -61,6 +62,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.StatusBarAlignment.Right,
     1000,
   )
+  logger.initialize('RuyiSDK')
   newsStatusBarItem.text = '$(info) Read RuyiNews'
   newsStatusBarItem.tooltip = 'Open Ruyi News Cards'
   newsStatusBarItem.command = 'ruyi.news.showCards'
@@ -81,4 +83,6 @@ export function activate(context: vscode.ExtensionContext) {
   })
 }
 
-export function deactivate() {}
+export function deactivate() {
+  logger.dispose()
+}

--- a/src/features/news/NewsService.ts
+++ b/src/features/news/NewsService.ts
@@ -326,7 +326,8 @@ export default class NewsService {
       }
       return text
     }
-    catch {
+    catch (error) {
+      logger.warn('Failed to extract summary:', error)
       return undefined
     }
   }

--- a/src/features/news/NewsService.ts
+++ b/src/features/news/NewsService.ts
@@ -17,6 +17,7 @@ import * as path from 'path'
 import { promisify } from 'util'
 import * as vscode from 'vscode'
 
+import { logger } from '../../common/logger.js'
 import ruyi from '../../common/ruyi'
 
 const resolve4 = promisify(dns.resolve4)
@@ -95,7 +96,7 @@ export default class NewsService {
       return cache
     }
     catch (error) {
-      console.warn('Failed to load news cache:', error)
+      logger.warn('Failed to load news cache:', error)
       return null
     }
   }
@@ -123,7 +124,7 @@ export default class NewsService {
       await vscode.workspace.fs.writeFile(cacheUri, Buffer.from(cacheContent, 'utf8'))
     }
     catch (error) {
-      console.warn('Failed to save news cache:', error)
+      logger.warn('Failed to save news cache:', error)
     }
   }
 
@@ -144,7 +145,7 @@ export default class NewsService {
         if (forceRefresh) {
           throw error
         }
-        console.warn('Network fetch failed, trying cache:', error)
+        logger.warn('Network fetch failed, trying cache:', error)
         return await this.fetchFromCache(unread)
       }
     }
@@ -206,17 +207,17 @@ export default class NewsService {
       const isOnline = await this.isNetworkAvailable()
       if (isOnline) {
         await this.list(false, true) // Force refresh
-        console.log('News service initialized')
+        logger.log('News service initialized')
       }
       else {
         const cache = await this.loadCache()
         if (cache) {
-          console.log(`News service initialized from cache with ${cache.data.length} items`)
+          logger.log(`News service initialized from cache with ${cache.data.length} items`)
         }
       }
     }
     catch (error) {
-      console.warn('Failed to initialize news service:', error)
+      logger.warn('Failed to initialize news service:', error)
     }
   }
 
@@ -257,7 +258,7 @@ export default class NewsService {
       }
     }
     catch (error) {
-      console.warn('Failed to mark news as read:', error)
+      logger.warn('Failed to mark news as read:', error)
     }
   }
 

--- a/src/features/packages/PackageService.ts
+++ b/src/features/packages/PackageService.ts
@@ -13,6 +13,7 @@
 
 import { VALID_PACKAGE_CATEGORIES } from '../../common/constants'
 import { parseNDJSON } from '../../common/helpers'
+import { logger } from '../../common/logger'
 import ruyi from '../../common/ruyi'
 
 export type PackageCategory = typeof VALID_PACKAGE_CATEGORIES[number] | 'unknown'
@@ -64,7 +65,7 @@ export class PackageService {
     try {
       const listResult = await ruyi.list()
       if (listResult.code !== 0) {
-        console.error('Failed to list packages:', listResult.stderr)
+        logger.error('Failed to list packages:', listResult.stderr)
         return []
       }
 
@@ -72,7 +73,7 @@ export class PackageService {
       return this.packages
     }
     catch (error) {
-      console.error('Error fetching packages:', error)
+      logger.error('Error fetching packages:', error)
       return []
     }
   }

--- a/src/features/packages/PackagesTree.ts
+++ b/src/features/packages/PackagesTree.ts
@@ -15,17 +15,19 @@
 
 import * as vscode from 'vscode'
 
+import { logger } from '../../common/logger.js'
+
 import { RuyiPackage, RuyiPackageVersion, PackageService } from './PackageService'
 
 // Define tree node types
 type TreeElement = PackageCategoryItem | PackageItem | VersionItem
 
 export class PackagesTreeProvider implements
-    vscode.TreeDataProvider<TreeElement> {
+  vscode.TreeDataProvider<TreeElement> {
   private _onDidChangeTreeData = new vscode.EventEmitter<void>()
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event
 
-  constructor(private packageService: PackageService) {}
+  constructor(private packageService: PackageService) { }
 
   /**
    * Refresh the tree view and force data refresh.
@@ -35,7 +37,7 @@ export class PackagesTreeProvider implements
       await this.packageService.getPackages(true)
     }
     catch (err) {
-      console.error('Failed to refresh packages:', err)
+      logger.error('Failed to refresh packages:', err)
     }
     finally {
       this._onDidChangeTreeData.fire()

--- a/src/features/venv/DetectforVenv.ts
+++ b/src/features/venv/DetectforVenv.ts
@@ -17,6 +17,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 
 import { getWorkspaceFolderPath } from '../../common/helpers'
+import { logger } from '../../common/logger'
 
 export function detectVenv(): string[][] {
   const foundVenvs: string[][] = []
@@ -36,7 +37,7 @@ export function detectVenv(): string[][] {
           .map(dirent => `${subdir}/${dirent.name}`)
       }
       catch (e) {
-        console.warn(`[Warning] Failed to read ${subdir}: ${e}`)
+        logger.warn(`Failed to read ${subdir}: ${e}`)
         return []
       }
     })
@@ -53,7 +54,7 @@ export function detectVenv(): string[][] {
     for (const dir of allDirsToCheck) {
       const segments = dir.split('/')
       if (!segments.every(isPathSafe)) {
-        console.warn(`Skipping unsafe path: ${dir}`)
+        logger.warn(`Skipping unsafe path: ${dir}`)
         continue
       }
 
@@ -71,7 +72,7 @@ export function detectVenv(): string[][] {
     }
   }
   catch (e) {
-    console.error(`[Error] Failed to detect venvs: ${e}`)
+    logger.error(`Failed to detect venvs: ${e}`)
   }
 
   return foundVenvs

--- a/src/features/venv/GetEmulators.ts
+++ b/src/features/venv/GetEmulators.ts
@@ -13,6 +13,7 @@
  * - getEmulators(): Get all Ruyi emulators and return as a Dict-array
  */
 
+import { logger } from '../../common/logger.js'
 import ruyi from '../../common/ruyi'
 
 interface EmulatorInfo {
@@ -48,7 +49,7 @@ export function parseStdoutE(text: string): EmulatorInfo[] {
     }
     catch (e) {
       // Output JSON parse errors
-      console.error('JSON parse error:', e)
+      logger.error('JSON parse error:', e)
     }
   }
 

--- a/src/features/venv/GetToolchains.ts
+++ b/src/features/venv/GetToolchains.ts
@@ -12,6 +12,7 @@
  *   used by getToolchains()
  * - getToolchains(): Get all Ruyi toolchains and return as a Object-array
  */
+import { logger } from '../../common/logger.js'
 import ruyi from '../../common/ruyi'
 
 interface Toolchain {
@@ -52,7 +53,7 @@ export function parseStdoutT(text: string): Toolchain[] {
     }
     catch (e) {
       // Output JSON parse errors
-      console.error('JSON parse error:', e)
+      logger.error('JSON parse error:', e)
     }
   }
 


### PR DESCRIPTION
此为 J163 pre-task 的一部分。

* 创建了新 logger 类，基于 VSCode `LogOutputChannel`，用法仿照 console
* 用 logger 替代了已有的 console，并统一了格式（如 log level、log 来源由方法自动生成，消息内一律删除）
* 检查了 try catch 块，保证所有异常都 `logger.warn` 汇报（已经弹窗提示处除外）。

已有异常处理我认为还能跑，所以没有大范围处理。我看见的小问题是有些可能会 throw 的函数并没有用 try 包裹，但测试时没有真的 throw 过，故没动。

如有其余需要修改之处，敬请指出。

## Summary by Sourcery

Introduce a unified logging system by adding a Logger class and replacing all console calls with structured logger methods, standardizing log output and ensuring consistent exception reporting throughout the extension

New Features:
- Introduce a Logger class wrapping VS Code's LogOutputChannel with console-like methods

Enhancements:
- Replace all console.log/info/warn/error calls with logger methods across the codebase
- Standardize log formatting and automatically include log level and source
- Ensure all caught exceptions are reported via logger.warn
- Initialize the logger during extension activation and dispose it on deactivation