### PR TITLE
fix(venv): update tree view state when terminal is closed

### DIFF
--- a/src/commands/venv/manageCurrentVenv.ts
+++ b/src/commands/venv/manageCurrentVenv.ts
@@ -21,6 +21,7 @@ export default function registerTerminalHandlerCommand(context: vscode.Extension
       if (closedTerminal === ruyiTerminal) {
         ruyiTerminal = undefined
         currentVenv = undefined
+        venvTree.setCurrentVenv(null, null)
         vscode.window.showInformationMessage('Ruyi Venv Terminal closed, venv deactivated.')
       }
     }),


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Invoke setCurrentVenv on the venv tree to clear the active environment after the terminal closes