### PR TITLE
refactor(venv): remove VenvPick interface in favor of VenvTreeItem

### DIFF
--- a/src/commands/venv/clean.ts
+++ b/src/commands/venv/clean.ts
@@ -11,7 +11,7 @@
 import * as path from 'path'
 import * as vscode from 'vscode'
 
-import { getWorkspaceFolderPath, VenvPick } from '../../common/helpers'
+import { getWorkspaceFolderPath } from '../../common/helpers'
 import { VenvTreeItem } from '../../features/venv/VenvTree'
 
 import { currentVenv } from './manageCurrentVenv'
@@ -22,11 +22,8 @@ export default function registerCleanADeactivatedVenvCommand(
     if (!venv) {
       return
     }
-    // Invoke detectVenv command to let user pick a venv to operate.
-    const pickedVenv: VenvPick
-      = { label: venv.name, description: '', rawPath: venv.venvPath }
     // Check if the picked venv is the current active one
-    const venvPath = `./${pickedVenv.rawPath}`
+    const venvPath = `./${venv.venvPath}`
     if (venvPath === currentVenv) {
       vscode.window.showErrorMessage('Cannot delete the currently active Ruyi venv. Please deactivate it first.')
       return

--- a/src/commands/venv/switch.ts
+++ b/src/commands/venv/switch.ts
@@ -10,20 +10,20 @@
 
 import * as vscode from 'vscode'
 
-import { VenvPick } from '../../common/helpers'
+import { VenvTreeItem } from '../../features/venv/VenvTree'
 
 import { manageRuyiTerminal, currentVenv } from './manageCurrentVenv'
 
 export default function registerSwitchFromVenvsCommand(
   context: vscode.ExtensionContext) {
-  const disposable = vscode.commands.registerCommand('ruyi.venv.switch', async (venv?: VenvPick) => {
+  const disposable = vscode.commands.registerCommand('ruyi.venv.switch', async (venv?: VenvTreeItem) => {
     // Invoke detectVenv command to let user pick a venv to operate.
     if (!venv) {
       return
     }
     // Manage the Ruyi terminal for venv activation/deactivation
-    const venvPath = `./${venv.rawPath}`
-    manageRuyiTerminal(venvPath === currentVenv ? null : venvPath, venvPath === currentVenv ? null : venv.label)
+    const venvPath = `./${venv.venvPath}`
+    manageRuyiTerminal(venvPath === currentVenv ? null : venvPath, venvPath === currentVenv ? null : venv.name)
 
     // Refresh the venv tree view to reflect the current active venv
     await vscode.commands.executeCommand('ruyi.venv.refresh', false)

--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -69,13 +69,3 @@ export function parseNDJSON<T>(output: string): T[] {
     })
     .filter(item => item !== null)
 }
-
-/**
- * Helper Interface for venv pick.
- */
-
-export interface VenvPick {
-  label: string
-  description: string
-  rawPath: string
-}

--- a/src/features/venv/VenvTree.ts
+++ b/src/features/venv/VenvTree.ts
@@ -145,7 +145,7 @@ export class VenvTreeItem extends vscode.TreeItem {
       this.command = {
         command: 'ruyi.venv.switch',
         title: 'Activate or Deactivate Venv',
-        arguments: [{ label: name, description: '', rawPath: venvPath }],
+        arguments: [this],
       }
     }
   }


### PR DESCRIPTION
## Summary by Sourcery

Refactor venv command implementations to drop the legacy VenvPick type and standardize on VenvTreeItem for picking and managing virtual environments.

Enhancements:
- Remove the VenvPick interface and its references from helpers.ts
- Update the venv switch and clean commands to accept VenvTreeItem and use its venvPath and name properties
- Change VenvTreeItem to pass itself directly as the command argument for activation/deactivation