### PR TITLE
refactor(ruyi): remove duplicate wrapper methods and align with CLI

### DIFF
--- a/src/common/ruyi.ts
+++ b/src/common/ruyi.ts
@@ -13,7 +13,6 @@ import * as path from 'path'
 
 import { configuration } from '../features/configuration/ConfigurationService'
 
-import { getWorkspaceFolderPath } from './helpers'
 import { logger } from './logger'
 
 // ============================================================================
@@ -122,7 +121,7 @@ export async function resolveRuyi(): Promise<string | null> {
   const pathEnv = process.env.PATH
   if (!pathEnv) return null
 
-  const pathDirs = pathEnv.split(':').filter(dir => dir.trim())
+  const pathDirs = pathEnv.split(path.delimiter).filter(dir => dir.trim())
   for (const dir of pathDirs) {
     try {
       const ruyiPath = path.join(dir, 'ruyi')
@@ -612,53 +611,6 @@ export class Ruyi {
 
     const status = enable ? await this.telemetryConsent() : await this.telemetryOptout()
     return { status }
-  }
-  // ============================================================================
-  // Venv Command
-  // ============================================================================
-
-  async venvCreate(
-    name: string,
-    toolchains: string[],
-    emulator: string | null,
-    sysrootFrom: string | undefined,
-    extraCommandsFrom: string[],
-    profile: string,
-    path: string,
-  ): Promise<RuyiResult> {
-    const args: string[] = ['venv', '--name', name]
-
-    for (const tc of toolchains) {
-      args.push('-t', tc)
-    }
-
-    if (emulator) {
-      args.push('--emulator', emulator)
-    }
-
-    if (sysrootFrom) {
-      args.push('--sysroot-from', sysrootFrom)
-    }
-
-    for (const ex of extraCommandsFrom) {
-      args.push('--extra-commands-from', ex)
-    }
-
-    args.push(profile, path)
-
-    return runRuyi(args, { cwd: getWorkspaceFolderPath(), env: this.options.env, timeout: 247000 })
-  }
-
-  async getEmulators(): Promise<RuyiResult> {
-    return runRuyi(['--porcelain', 'list', '--category-is', 'emulator'], this.options)
-  }
-
-  async getToolchains(): Promise<RuyiResult> {
-    return runRuyi(['--porcelain', 'list', '--category-is', 'toolchain'], this.options)
-  }
-
-  async getProfiles(): Promise<RuyiResult> {
-    return runRuyi(['--porcelain', 'list', 'profiles'], this.options)
   }
 
   // ============================================================================

--- a/src/features/venv/CreateVenv.ts
+++ b/src/features/venv/CreateVenv.ts
@@ -6,11 +6,21 @@
  * - createVenv(profile, toolchain, emulator, name, path): create a Ruyi venv
  */
 
+import { getWorkspaceFolderPath } from '../../common/helpers'
 import ruyi from '../../common/ruyi'
 
 export async function createVenv(profile: string, toolchains: string[], emulator: string | null,
   name: string, path: string, sysrootFrom: string | undefined, extraCommandsFrom: string[]): Promise<string> {
-  const result = await ruyi.venvCreate(name, toolchains, emulator, sysrootFrom, extraCommandsFrom, profile, path)
+  const result = await ruyi
+    .timeout(5 * 60 * 1000)
+    .cwd(getWorkspaceFolderPath())
+    .venv(profile, path, {
+      name,
+      toolchain: toolchains,
+      emulator: emulator ?? undefined,
+      sysrootFrom,
+      extraCommandsFrom,
+    })
   if (result.code == 0) {
     return `Succeeded: ${result.stderr}. \n\
       Now you can activate the new venv with our extension or via the terminal.`

--- a/src/features/venv/GetEmulators.ts
+++ b/src/features/venv/GetEmulators.ts
@@ -58,7 +58,7 @@ export function parseStdoutE(text: string): EmulatorInfo[] {
 
 export async function getEmulators():
 Promise<{ name: string, semver: string, remarks: string }[] | { errorMsg: string }> {
-  const result = await ruyi.getEmulators()
+  const result = await ruyi.list({ categoryIs: 'emulator' })
   if (result.code == 0) {
     const emus = parseStdoutE(result.stdout)
     return emus

--- a/src/features/venv/GetProfiles.ts
+++ b/src/features/venv/GetProfiles.ts
@@ -24,7 +24,7 @@ export function readStdoutP(stdout: string): Record<string, string> {
 
 export async function getProfiles(): Promise<{ [key: string]: string }> {
   let profiles: { [key: string]: string } = {}
-  const result = await ruyi.getProfiles()
+  const result = await ruyi.listProfiles()
   if (result.code == 0) {
     profiles = readStdoutP(result.stdout)
   }

--- a/src/features/venv/GetToolchains.ts
+++ b/src/features/venv/GetToolchains.ts
@@ -62,7 +62,7 @@ export function parseStdoutT(text: string): Toolchain[] {
 
 export async function getToolchains(): Promise<Toolchain[]> {
   let toolchains: Toolchain[] = []
-  const result = await ruyi.getToolchains()
+  const result = await ruyi.list({ categoryIs: 'toolchain' })
   if (result.code == 0) {
     toolchains = parseStdoutT(result.stdout)
   }


### PR DESCRIPTION
## Summary by Sourcery

Refactor Ruyi integration to use a unified, chainable CLI wrapper API and update venv feature modules accordingly while making PATH resolution platform-agnostic

Enhancements:
- Use Node’s path.delimiter for cross-platform PATH splitting
- Remove specific Ruyi wrapper methods in favour of generic, chainable CLI commands (venv, list, listProfiles)
- Update CreateVenv, GetEmulators, GetProfiles, and GetToolchains to invoke the new Ruyi chainable API with timeout and cwd settings