### PR TITLE
refactor: reorganize Ruyi module and simplify type definitions

### DIFF
--- a/src/commands/detect.ts
+++ b/src/commands/detect.ts
@@ -9,9 +9,9 @@ import * as vscode from 'vscode'
 import * as semver from 'semver'
 
 import { logger } from '../common/logger.js'
-import ruyi, { resolveRuyi } from '../common/ruyi'
 import { configuration } from '../features/configuration/ConfigurationService'
 import { promptForTelemetryConfiguration } from '../features/telemetry/TelemetryService'
+import ruyi, { resolveRuyi } from '../ruyi'
 
 interface GitHubRelease {
   tag_name: string

--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -12,23 +12,13 @@ import * as path from 'path'
 import * as vscode from 'vscode'
 
 import { createProgressTracker, parseNDJSON } from '../common/helpers'
-import ruyi from '../common/ruyi'
+import ruyi from '../ruyi'
+import type { RuyiPorcelainPackageOutput } from '../ruyi/types'
 
 /**
  * Parse the NDJSON output of `ruyi --porcelain list` to get source packages.
  * Each line is a separate JSON object.
  */
-interface RuyiPorcelainPackageOutput {
-  ty: string
-  category: string
-  name: string
-  vers: Array<{
-    semver: string
-    remarks: string[]
-    is_installed: boolean
-    is_downloaded: boolean
-  }>
-}
 
 function parseSourcePackages(output: string): string[] {
   const packages = parseNDJSON<RuyiPorcelainPackageOutput>(output)

--- a/src/commands/installRuyi.ts
+++ b/src/commands/installRuyi.ts
@@ -17,8 +17,8 @@ import * as util from 'util'
 import * as vscode from 'vscode'
 
 import { logger } from '../common/logger.js'
-import ruyi, { resolveRuyi } from '../common/ruyi'
 import { promptForTelemetryConfiguration } from '../features/telemetry/TelemetryService'
+import ruyi, { resolveRuyi } from '../ruyi'
 
 const execAsync = util.promisify(cp.exec)
 

--- a/src/commands/packages.ts
+++ b/src/commands/packages.ts
@@ -11,9 +11,9 @@
 import * as vscode from 'vscode'
 
 import { createProgressTracker } from '../common/helpers'
-import ruyi from '../common/ruyi'
 import { PackageService } from '../features/packages/PackageService'
 import { PackagesTreeProvider, VersionItem } from '../features/packages/PackagesTree'
+import ruyi from '../ruyi'
 
 export default function registerPackagesCommands(ctx: vscode.ExtensionContext) {
   // Initialize service and tree provider

--- a/src/features/news/NewsService.ts
+++ b/src/features/news/NewsService.ts
@@ -18,7 +18,7 @@ import { promisify } from 'util'
 import * as vscode from 'vscode'
 
 import { logger } from '../../common/logger.js'
-import ruyi from '../../common/ruyi'
+import ruyi from '../../ruyi'
 
 const resolve4 = promisify(dns.resolve4)
 

--- a/src/features/telemetry/TelemetryService.ts
+++ b/src/features/telemetry/TelemetryService.ts
@@ -9,7 +9,7 @@ import * as vscode from 'vscode'
 
 import { CONFIG_KEYS } from '../../common/constants'
 import { fullKey } from '../../common/helpers'
-import ruyi from '../../common/ruyi'
+import ruyi from '../../ruyi'
 import { configuration } from '../configuration/ConfigurationService'
 
 /**

--- a/src/features/venv/CreateVenv.ts
+++ b/src/features/venv/CreateVenv.ts
@@ -7,7 +7,7 @@
  */
 
 import { getWorkspaceFolderPath } from '../../common/helpers'
-import ruyi from '../../common/ruyi'
+import ruyi from '../../ruyi'
 
 export async function createVenv(profile: string, toolchains: string[], emulator: string | null,
   name: string, path: string, sysrootFrom: string | undefined, extraCommandsFrom: string[]): Promise<string> {

--- a/src/features/venv/GetEmulators.ts
+++ b/src/features/venv/GetEmulators.ts
@@ -14,7 +14,8 @@
  */
 
 import { parseNDJSON } from '../../common/helpers'
-import ruyi from '../../common/ruyi'
+import ruyi from '../../ruyi'
+import type { RuyiEmulatorListItem } from '../../ruyi/types'
 
 interface EmulatorInfo {
   name: string
@@ -26,10 +27,7 @@ export function parseStdoutE(text: string): EmulatorInfo[] {
   const result: EmulatorInfo[] = []
 
   // Use parseNDJSON helper to parse newline-delimited JSON
-  const objects = parseNDJSON<{ name?: string, vers?: Array<{
-    semver?: string
-    remarks?: string | string[]
-  }> }>(text)
+  const objects = parseNDJSON<RuyiEmulatorListItem>(text)
 
   for (const obj of objects) {
     const name = obj.name || ''
@@ -37,10 +35,8 @@ export function parseStdoutE(text: string): EmulatorInfo[] {
     if (Array.isArray(obj.vers)) {
       for (const v of obj.vers) {
         const semver = v.semver || ''
-        // Concat the array of remarks into a single string
-        const remarks = Array.isArray(v.remarks)
-          ? v.remarks.join(', ')
-          : (v.remarks || '')
+        // remarks is always an array based on actual CLI output
+        const remarks = (v.remarks || []).join(', ')
         result.push({ name, semver, remarks })
       }
     }

--- a/src/features/venv/GetProfiles.ts
+++ b/src/features/venv/GetProfiles.ts
@@ -7,7 +7,7 @@
  * - getProfiles(): Get all Ruyi profiles and return as a dictionary (deduplicated)
  */
 
-import ruyi from '../../common/ruyi'
+import ruyi from '../../ruyi'
 
 export function readStdoutP(stdout: string): Record<string, string> {
   const dict: Record<string, string> = {}

--- a/src/features/venv/GetToolchains.ts
+++ b/src/features/venv/GetToolchains.ts
@@ -13,7 +13,8 @@
  * - getToolchains(): Get all Ruyi toolchains and return as a Object-array
  */
 import { parseNDJSON } from '../../common/helpers'
-import ruyi from '../../common/ruyi'
+import ruyi from '../../ruyi'
+import type { RuyiToolchainListItem } from '../../ruyi/types'
 
 interface Toolchain {
   name: string
@@ -27,11 +28,7 @@ export function parseStdoutT(text: string): Toolchain[] {
   const result: Toolchain[] = []
 
   // Use parseNDJSON helper to parse newline-delimited JSON
-  const objects = parseNDJSON<{ name?: string, vers?: Array<{
-    semver?: string
-    remarks?: string | string[]
-    pm?: { metadata?: { slug?: string } }
-  }> }>(text)
+  const objects = parseNDJSON<RuyiToolchainListItem>(text)
 
   for (const obj of objects) {
     const name = obj.name || ''
@@ -39,10 +36,8 @@ export function parseStdoutT(text: string): Toolchain[] {
     if (Array.isArray(obj.vers)) {
       for (const v of obj.vers) {
         const semver = v.semver || ''
-        // Concat the array of remarks into a single string
-        const remarks = Array.isArray(v.remarks)
-          ? v.remarks.join(', ')
-          : (v.remarks || '')
+        // remarks is always an array based on actual CLI output
+        const remarks = v.remarks || []
         const slug = v.pm?.metadata?.slug || null
         const installed = remarks.includes('installed')
         const latest = remarks.includes('latest')

--- a/src/ruyi/index.ts
+++ b/src/ruyi/index.ts
@@ -11,9 +11,8 @@ import type { SpawnOptions } from 'child_process'
 import * as fs from 'fs'
 import * as path from 'path'
 
+import { logger } from '../common/logger'
 import { configuration } from '../features/configuration/ConfigurationService'
-
-import { logger } from './logger'
 
 // ============================================================================
 // Types

--- a/src/ruyi/types.ts
+++ b/src/ruyi/types.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Type Definitions for Ruyi CLI Output
+ * Based on --porcelain (NDJSON) output format
+ */
+
+/** Base version information for all package types */
+export interface RuyiVersionBase {
+  semver: string
+  remarks: string[] // Always an array, e.g. ["latest"], ["latest", "installed"]
+  is_downloaded: boolean
+  is_installed: boolean
+}
+
+/** Base package metadata (common fields) */
+export interface RuyiPackageMetadata {
+  format: string
+  metadata: {
+    desc?: string
+    vendor?: {
+      name: string
+      eula: string
+    }
+    slug?: string
+  }
+  kind?: string[]
+}
+
+/** Toolchain metadata with toolchain-specific fields */
+export interface RuyiToolchainMetadata extends RuyiPackageMetadata {
+  toolchain: {
+    target: string
+    flavors?: string[]
+    components?: Array<{
+      name: string
+      version: string
+    }>
+    included_sysroot?: string
+  }
+}
+
+/** Emulator metadata with emulator-specific fields */
+export interface RuyiEmulatorMetadata extends RuyiPackageMetadata {
+  emulator: {
+    flavors?: string[]
+    programs?: Array<{
+      path: string
+      flavor: string
+      supported_arches?: string[]
+    }>
+  }
+}
+
+/** Regular package version info */
+export interface RuyiPackageVersionInfo extends RuyiVersionBase {
+  pm?: RuyiPackageMetadata
+}
+
+/** Toolchain package version info */
+export interface RuyiToolchainVersionInfo extends RuyiVersionBase {
+  pm: RuyiToolchainMetadata
+}
+
+/** Emulator package version info */
+export interface RuyiEmulatorVersionInfo extends RuyiVersionBase {
+  pm: RuyiEmulatorMetadata
+}
+
+/** Generic list item with name and versions */
+export interface RuyiListItem<V = RuyiVersionBase> {
+  name: string
+  vers: V[]
+}
+
+/** Full package output from `ruyi --porcelain list` */
+export interface RuyiPorcelainPackageOutput {
+  ty: string
+  category: string
+  name: string
+  vers: RuyiPackageVersionInfo[]
+}
+
+/** Toolchain list item */
+export type RuyiToolchainListItem = RuyiListItem<RuyiToolchainVersionInfo>
+
+/** Emulator list item */
+export type RuyiEmulatorListItem = RuyiListItem<RuyiEmulatorVersionInfo>


### PR DESCRIPTION
## Summary by Sourcery

Reorganize the Ruyi integration by centralizing type definitions, standardizing NDJSON parsing with a helper, and updating module import paths.

Enhancements:
- Extract Ruyi CLI output types into a new `src/ruyi/types.ts` and reorganize the Ruyi module exports
- Refactor toolchain, emulator, and package parsing to use the shared `parseNDJSON` helper instead of manual JSON parsing
- Update import paths to the relocated `ruyi` module and import corresponding type definitions across features
- Simplify slug extraction in `PackageService` to derive the slug from metadata or remarks