### PR TITLE
refactor: reorganize type definitions and add PackageCategory type

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -3,25 +3,10 @@
  * RuyiSDK VS Code Extension - Common Constants
  *
  * Responsibilities:
- *  - Define shared error codes and constants used across the extension
- *  - Provide standard timeout values for command execution
+ *  - Define shared constants used across the extension
  */
 
 export type ConfigKey = typeof CONFIG_KEYS[keyof typeof CONFIG_KEYS]
-
-/** Error code constants */
-export const ERR_NOT_SUPPORTED = -126 // Platform not supported
-export const ERR_RUYI_NOT_FOUND = -127 // Ruyi command not found
-
-/** Valid package categories */
-export const VALID_PACKAGE_CATEGORIES = [
-  'toolchain',
-  'source',
-  'emulator',
-  'board-image',
-  'analyzer',
-  'extra',
-] as const
 
 /** Configuration keys */
 export const CONFIG_KEYS = {

--- a/src/features/packages/PackageService.ts
+++ b/src/features/packages/PackageService.ts
@@ -11,13 +11,12 @@
  * - Caches results to minimize CLI calls
  */
 
-import { VALID_PACKAGE_CATEGORIES } from '../../common/constants'
 import { parseNDJSON } from '../../common/helpers'
 import { logger } from '../../common/logger'
-import ruyi from '../../ruyi'
+import ruyi, { PACKAGE_CATEGORIES, type PackageCategory as RuyiPackageCategory } from '../../ruyi'
 import type { RuyiPorcelainPackageOutput } from '../../ruyi/types'
 
-export type PackageCategory = typeof VALID_PACKAGE_CATEGORIES[number] | 'unknown'
+export type PackageCategory = RuyiPackageCategory | 'unknown'
 
 export interface RuyiPackageVersion {
   version: string
@@ -107,8 +106,8 @@ export class PackageService {
    * Normalize category string to PackageCategory type.
    */
   private normalizeCategory(category: string): PackageCategory {
-    if ((VALID_PACKAGE_CATEGORIES as readonly string[]).includes(category)) {
-      return category as PackageCategory
+    if (PACKAGE_CATEGORIES.includes(category as RuyiPackageCategory)) {
+      return category as RuyiPackageCategory
     }
 
     return 'unknown'

--- a/src/ruyi/index.ts
+++ b/src/ruyi/index.ts
@@ -18,6 +18,10 @@ import { configuration } from '../features/configuration/ConfigurationService'
 // Types
 // ============================================================================
 
+// ----------------------------------------------------------------------------
+// Basic Execution Types
+// ----------------------------------------------------------------------------
+
 export interface RuyiResult {
   stdout: string
   stderr: string
@@ -41,21 +45,32 @@ export interface RuyiRunOptions {
   onProgress?: ProgressCallback
 }
 
+// ----------------------------------------------------------------------------
+// Enums and Constants
+// ----------------------------------------------------------------------------
+
 export type TelemetryStatus = 'on' | 'off' | 'local' | 'unknown'
 
-export interface ListOptions {
-  verbose?: boolean
-  isInstalled?: boolean
-  categoryContains?: string
-  categoryIs?: string
-  nameContains?: string
-}
+/**
+ * Valid values for the --category-is parameter
+ */
+export const PACKAGE_CATEGORIES = [
+  'toolchain',
+  'source',
+  'emulator',
+  'board-image',
+  'analyzer',
+  'extra',
+] as const
 
-export interface InstallOptions {
-  fetchOnly?: boolean
-  host?: string
-  reinstall?: boolean
-}
+/**
+ * Package category type derived from PACKAGE_CATEGORIES
+ */
+export type PackageCategory = typeof PACKAGE_CATEGORIES[number]
+
+// ----------------------------------------------------------------------------
+// Command Options Interfaces
+// ----------------------------------------------------------------------------
 
 export interface ExtractOptions {
   destDir?: string
@@ -64,13 +79,18 @@ export interface ExtractOptions {
   host?: string
 }
 
-export interface VenvOptions {
-  name?: string
-  toolchain?: string | string[]
-  emulator?: string
-  withSysroot?: boolean
-  sysrootFrom?: string
-  extraCommandsFrom?: string | string[]
+export interface InstallOptions {
+  fetchOnly?: boolean
+  host?: string
+  reinstall?: boolean
+}
+
+export interface ListOptions {
+  verbose?: boolean
+  isInstalled?: boolean
+  categoryContains?: string
+  categoryIs?: PackageCategory
+  nameContains?: string
 }
 
 export interface NewsListOptions {
@@ -85,6 +105,15 @@ export interface SelfCleanOptions {
   progcache?: boolean
   repo?: boolean
   telemetry?: boolean
+}
+
+export interface VenvOptions {
+  name?: string
+  toolchain?: string | string[]
+  emulator?: string
+  withSysroot?: boolean
+  sysrootFrom?: string
+  extraCommandsFrom?: string | string[]
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary by Sourcery

Consolidate and reorganize type definitions by centralizing package category constants and introducing a derived PackageCategory type, updating related interfaces and services to use the new definitions.

Enhancements:
- Introduce PACKAGE_CATEGORIES constant and derive PackageCategory type in the ruyi module
- Reorganize command option interfaces in ruyi/index.ts into clearly labeled sections
- Remove duplicated package category and error code constants from common/constants.ts
- Update PackageService to use PACKAGE_CATEGORIES and the new PackageCategory type instead of legacy constants