### PR TITLE
refactor(ruyi): remove duplicate types

### DIFF
--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -13,7 +13,7 @@ import * as vscode from 'vscode'
 
 import { createProgressTracker, parseNDJSON } from '../common/helpers'
 import ruyi from '../ruyi'
-import type { RuyiPorcelainPackageOutput } from '../ruyi/types'
+import type { RuyiListOutput } from '../ruyi/types'
 
 /**
  * Parse the NDJSON output of `ruyi --porcelain list` to get source packages.
@@ -21,7 +21,7 @@ import type { RuyiPorcelainPackageOutput } from '../ruyi/types'
  */
 
 function parseSourcePackages(output: string): string[] {
-  const packages = parseNDJSON<RuyiPorcelainPackageOutput>(output)
+  const packages = parseNDJSON<RuyiListOutput>(output)
     .filter(item => item.ty === 'pkglistoutput-v1' && item.category === 'source')
     .map(item => `${item.category}/${item.name}`)
 

--- a/src/features/packages/PackageService.ts
+++ b/src/features/packages/PackageService.ts
@@ -14,7 +14,7 @@
 import { parseNDJSON } from '../../common/helpers'
 import { logger } from '../../common/logger'
 import ruyi, { PACKAGE_CATEGORIES, type PackageCategory } from '../../ruyi'
-import type { RuyiPorcelainPackageOutput } from '../../ruyi/types'
+import type { RuyiListOutput } from '../../ruyi/types'
 
 export interface RuyiPackageVersion {
   version: string
@@ -66,7 +66,7 @@ export class PackageService {
    * Each line is a separate JSON object.
    */
   private parsePorcelainListOutput(output: string): RuyiPackage[] {
-    return parseNDJSON<RuyiPorcelainPackageOutput>(output)
+    return parseNDJSON<RuyiListOutput>(output)
       .filter(item => item.ty === 'pkglistoutput-v1')
       // Exclude 'source' category
       .filter(item => item.category !== 'source')

--- a/src/features/venv/GetEmulators.ts
+++ b/src/features/venv/GetEmulators.ts
@@ -15,7 +15,7 @@
 
 import { parseNDJSON } from '../../common/helpers'
 import ruyi from '../../ruyi'
-import type { RuyiEmulatorListItem } from '../../ruyi/types'
+import type { RuyiListOutput } from '../../ruyi/types'
 
 interface EmulatorInfo {
   name: string
@@ -27,7 +27,7 @@ export function parseStdoutE(text: string): EmulatorInfo[] {
   const result: EmulatorInfo[] = []
 
   // Use parseNDJSON helper to parse newline-delimited JSON
-  const objects = parseNDJSON<RuyiEmulatorListItem>(text)
+  const objects = parseNDJSON<RuyiListOutput>(text)
 
   for (const obj of objects) {
     const name = obj.name || ''

--- a/src/features/venv/GetToolchains.ts
+++ b/src/features/venv/GetToolchains.ts
@@ -14,7 +14,7 @@
  */
 import { parseNDJSON } from '../../common/helpers'
 import ruyi from '../../ruyi'
-import type { RuyiToolchainListItem } from '../../ruyi/types'
+import type { RuyiListOutput } from '../../ruyi/types'
 
 interface Toolchain {
   name: string
@@ -28,7 +28,7 @@ export function parseStdoutT(text: string): Toolchain[] {
   const result: Toolchain[] = []
 
   // Use parseNDJSON helper to parse newline-delimited JSON
-  const objects = parseNDJSON<RuyiToolchainListItem>(text)
+  const objects = parseNDJSON<RuyiListOutput>(text)
 
   for (const obj of objects) {
     const name = obj.name || ''

--- a/src/ruyi/types.ts
+++ b/src/ruyi/types.ts
@@ -1,87 +1,23 @@
 // SPDX-License-Identifier: Apache-2.0
-/**
- * Type Definitions for Ruyi CLI Output
- * Based on --porcelain (NDJSON) output format
- */
 
-/** Base version information for all package types */
-export interface RuyiVersionBase {
+/** Version information for a package */
+export interface RuyiVersionInfo {
   semver: string
-  remarks: string[] // Always an array, e.g. ["latest"], ["latest", "installed"]
+  remarks: string[]
   is_downloaded: boolean
   is_installed: boolean
-}
-
-/** Base package metadata (common fields) */
-export interface RuyiPackageMetadata {
-  format: string
-  metadata: {
-    desc?: string
-    vendor?: {
-      name: string
-      eula: string
+  pm?: {
+    metadata?: {
+      desc?: string
+      slug?: string
     }
-    slug?: string
-  }
-  kind?: string[]
-}
-
-/** Toolchain metadata with toolchain-specific fields */
-export interface RuyiToolchainMetadata extends RuyiPackageMetadata {
-  toolchain: {
-    target: string
-    flavors?: string[]
-    components?: Array<{
-      name: string
-      version: string
-    }>
-    included_sysroot?: string
   }
 }
 
-/** Emulator metadata with emulator-specific fields */
-export interface RuyiEmulatorMetadata extends RuyiPackageMetadata {
-  emulator: {
-    flavors?: string[]
-    programs?: Array<{
-      path: string
-      flavor: string
-      supported_arches?: string[]
-    }>
-  }
-}
-
-/** Regular package version info */
-export interface RuyiPackageVersionInfo extends RuyiVersionBase {
-  pm?: RuyiPackageMetadata
-}
-
-/** Toolchain package version info */
-export interface RuyiToolchainVersionInfo extends RuyiVersionBase {
-  pm: RuyiToolchainMetadata
-}
-
-/** Emulator package version info */
-export interface RuyiEmulatorVersionInfo extends RuyiVersionBase {
-  pm: RuyiEmulatorMetadata
-}
-
-/** Generic list item with name and versions */
-export interface RuyiListItem<V = RuyiVersionBase> {
-  name: string
-  vers: V[]
-}
-
-/** Full package output from `ruyi --porcelain list` */
-export interface RuyiPorcelainPackageOutput {
+/** Output line from `ruyi --porcelain list` */
+export interface RuyiListOutput {
   ty: string
   category: string
   name: string
-  vers: RuyiPackageVersionInfo[]
+  vers: RuyiVersionInfo[]
 }
-
-/** Toolchain list item */
-export type RuyiToolchainListItem = RuyiListItem<RuyiToolchainVersionInfo>
-
-/** Emulator list item */
-export type RuyiEmulatorListItem = RuyiListItem<RuyiEmulatorVersionInfo>


### PR DESCRIPTION
## Summary by Sourcery

Refactor ruyi type definitions to remove duplication and streamline NDJSON list parsing by consolidating multiple interfaces into unified RuyiVersionInfo and RuyiListOutput types.

Enhancements:
- Simplify and unify type definitions by replacing various version, metadata, and list item interfaces with RuyiVersionInfo and RuyiListOutput
- Update parsing code in PackageService, GetEmulators, GetToolchains, and extract command to use the new unified types