### PR TITLE
refactor: move status bar creation from extension.ts to command layer

### DIFF
--- a/src/commands/news.ts
+++ b/src/commands/news.ts
@@ -13,15 +13,22 @@ import NewsCards from '../features/news/NewsCards'
 import NewsService from '../features/news/NewsService'
 
 export default function registerNewsCommands(ctx: vscode.ExtensionContext) {
+  // Create status bar entry for quick access to news
+  const newsStatusBarItem = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Right,
+    1000,
+  )
+  newsStatusBarItem.text = '$(info) Read RuyiNews'
+  newsStatusBarItem.tooltip = 'Open Ruyi News Cards'
+  newsStatusBarItem.command = 'ruyi.news.showCards'
+  newsStatusBarItem.show()
+  ctx.subscriptions.push(newsStatusBarItem)
+
   const svc = NewsService.getInstance(ctx)
   const cardsProvider = new NewsCards(svc)
-
-  // Initialize news service
   svc.initialize().catch((err: unknown) =>
     logger.warn('Failed to initialize news service:', err),
   )
-
-  // Note: Tree view is removed, only cards view is available
 
   const searchCmd = vscode.commands.registerCommand(
     'ruyi.news.search', async () => {

--- a/src/commands/venv/detect.ts
+++ b/src/commands/venv/detect.ts
@@ -24,6 +24,20 @@ export const venvTree = new VenvTreeProvider()
 
 export default function registerDetectAllVenvsCommand(
   context: vscode.ExtensionContext) {
+  // Create status bar item for venv management
+  const venvStatusBarItem = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Left,
+    1000,
+  )
+  venvStatusBarItem.text = '$(circle-slash) No Active Venv'
+  venvStatusBarItem.tooltip = 'Manage Ruyi Virtual Environments'
+  venvStatusBarItem.command = 'ruyiVenvsView.focus'
+  venvStatusBarItem.show()
+  context.subscriptions.push(venvStatusBarItem)
+
+  // Link status bar to VenvTree for automatic updates
+  venvTree.setStatusBarItem(venvStatusBarItem)
+
   const disposable = vscode.commands.registerCommand(
     'ruyi.venv.refresh', async (active: boolean = true) => {
       const venvs = detectVenv()

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,7 +33,7 @@ import registerNewsCommands from './commands/news'
 import registerPackagesCommands from './commands/packages'
 import registerCleanADeactivatedVenvCommand from './commands/venv/clean'
 import registerCreateNewVenvCommand from './commands/venv/create'
-import registerDetectAllVenvsCommand, { venvTree } from './commands/venv/detect'
+import registerDetectAllVenvsCommand from './commands/venv/detect'
 import registerTerminalHandlerCommand from './commands/venv/manageCurrentVenv'
 import registerSwitchFromVenvsCommand from './commands/venv/switch'
 import { logger } from './common/logger'
@@ -57,27 +57,8 @@ export function activate(context: vscode.ExtensionContext) {
   registerSwitchFromVenvsCommand(context)
   registerCleanADeactivatedVenvCommand(context)
 
-  // Create status bar entry for Ruyi News Cards
-  const newsStatusBarItem = vscode.window.createStatusBarItem(
-    vscode.StatusBarAlignment.Right,
-    1000,
-  )
+  // Initialize logger
   logger.initialize('RuyiSDK')
-  newsStatusBarItem.text = '$(info) Read RuyiNews'
-  newsStatusBarItem.tooltip = 'Open Ruyi News Cards'
-  newsStatusBarItem.command = 'ruyi.news.showCards'
-  newsStatusBarItem.show()
-  context.subscriptions.push(newsStatusBarItem)
-
-  const venvStatusBarItem = vscode.window.createStatusBarItem(
-    vscode.StatusBarAlignment.Left,
-    1000,
-  )
-  venvStatusBarItem.text = '$(circle-slash) No Active Venv'
-  venvStatusBarItem.tooltip = 'Manage Ruyi Virtual Environments'
-  venvStatusBarItem.command = 'ruyiVenvsView.focus'
-  venvStatusBarItem.show()
-  context.subscriptions.push(venvStatusBarItem)
 
   // Run initial detection
   setTimeout(async () => {
@@ -89,8 +70,7 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     await vscode.commands.executeCommand('ruyi.detect')
-      .then(() => vscode.commands.executeCommand('ruyi.venv.refresh', false))
-      .then(() => venvTree.setStatusBarItem(venvStatusBarItem))
+    await vscode.commands.executeCommand('ruyi.venv.refresh', false)
   })
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Refactor extension initialization by relocating status bar item creation for news and virtual environments from the main extension activation to their respective command modules

Enhancements:
- Move creation of news status bar item into news command registration
- Move creation of venv status bar item into venv detection command registration