### PR TITLE
fix(venv): create TreeView only once to prevent resource leak

### DIFF
--- a/src/commands/venv/detect.ts
+++ b/src/commands/venv/detect.ts
@@ -34,9 +34,13 @@ export default function registerDetectAllVenvsCommand(
   venvStatusBarItem.command = 'ruyiVenvsView.focus'
   venvStatusBarItem.show()
   context.subscriptions.push(venvStatusBarItem)
-
-  // Link status bar to VenvTree for automatic updates
   venvTree.setStatusBarItem(venvStatusBarItem)
+
+  // Create tree view for venv management
+  const venvTreeView = vscode.window.createTreeView('ruyiVenvsView', {
+    treeDataProvider: venvTree,
+  })
+  context.subscriptions.push(venvTreeView)
 
   const disposable = vscode.commands.registerCommand(
     'ruyi.venv.refresh', async () => {
@@ -47,10 +51,6 @@ export default function registerDetectAllVenvsCommand(
         path: v[0],
       }))
       venvTree.updateVenvs(venvInfo)
-      const venvTreeView = vscode.window.createTreeView('ruyiVenvsView', {
-        treeDataProvider: venvTree,
-      })
-      context.subscriptions.push(venvTreeView)
     })
   context.subscriptions.push(disposable)
 }


### PR DESCRIPTION
## Summary by Sourcery

Prevent resource leak by creating the virtual environment TreeView only once during command registration and removing its redundant instantiation on refresh.

Bug Fixes:
- Prevent resource leak by only creating the venv TreeView once instead of on each refresh.

Enhancements:
- Move TreeView creation to initial setup and remove redundant instantiation from the refresh command.
- Add clarifying comment for TreeView creation.