### PR TITLE
fix(venv): remove redundant ellipsis from progress notification title

### DIFF
--- a/src/commands/venv/create.ts
+++ b/src/commands/venv/create.ts
@@ -248,7 +248,7 @@ export default function registerCreateNewVenvCommand(
     await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,
-        title: `Creating venv "${name}"...`,
+        title: `Creating venv "${name}"`,
         cancellable: false,
       },
       async (progress) => {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Remove trailing '...' from the notification title when creating a virtual environment