### PR TITLE
refactor: replaced sync node.js fs API to async VSCode fs API

### DIFF
--- a/src/commands/venv/detect.ts
+++ b/src/commands/venv/detect.ts
@@ -44,7 +44,7 @@ export default function registerDetectAllVenvsCommand(
 
   const disposable = vscode.commands.registerCommand(
     'ruyi.venv.refresh', async () => {
-      const venvs = detectVenv()
+      const venvs = await detectVenv()
       // Update tree view with detected venvs
       const venvInfo: VenvInfo[] = venvs.map(v => ({
         name: v[1],


### PR DESCRIPTION
## Summary by Sourcery

Replace synchronous Node.js fs operations with VSCode's asynchronous workspace.fs API across venv detection, ruyi resolution, and command modules, converting functions to return promises.

Enhancements:
- Refactor detectVenv to be async and replace readdirSync, existsSync, and readFileSync with workspace.fs.readDirectory, stat, and readFile
- Update resolveRuyi to use workspace.fs.stat for path checks instead of fs.existsSync
- Modify command registration to await the asynchronous detectVenv result