### PR TITLE
fix(news): force ruyi update before refreshing cache

### DIFF
--- a/src/news/news.service.ts
+++ b/src/news/news.service.ts
@@ -125,6 +125,10 @@ export class NewsService {
   }
 
   async list(unread = false, forceRefresh = false): Promise<NewsRow[]> {
+    if (forceRefresh) {
+      await this.refreshNewsRepo()
+    }
+
     const shouldTryNetwork = forceRefresh || await this.isNetworkAvailable()
 
     if (shouldTryNetwork) {
@@ -231,6 +235,13 @@ export class NewsService {
     }
     catch (error) {
       logger.warn('Failed to mark news as read:', error)
+    }
+  }
+
+  private async refreshNewsRepo(): Promise<void> {
+    const result = await ruyi.update()
+    if (result.code !== 0) {
+      throw new Error(result.stderr || 'ruyi update failed')
     }
   }
 }


### PR DESCRIPTION
- run `ruyi update` whenever `NewsService.list()` is called with `forceRefresh` so the CLI repo is up to date before fetching news
- encapsulate the update logic in a new private `refreshNewsRepo()` helper to keep the refresh flow tidy

## Summary by Sourcery

Ensure news listing refreshes the underlying CLI news repository before attempting to fetch updates when a forced refresh is requested.

Bug Fixes:
- Trigger a ruyi repository update whenever news is listed with force refresh to avoid using stale CLI metadata.

Enhancements:
- Encapsulate the news repository update logic in a dedicated helper method for clearer refresh flow and error handling.