### PR TITLE
refactor(packages): unify export style

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,7 +35,7 @@ import { configuration } from './common/configuration'
 import { logger } from './common/logger'
 import registerHomeModule from './home'
 import registerNewsModule from './news'
-import { registerPackagesModule } from './packages'
+import registerPackagesModule from './packages'
 import { registerTelemetryModule } from './telemetry'
 
 export function activate(context: vscode.ExtensionContext) {

--- a/src/packages/extract.command.ts
+++ b/src/packages/extract.command.ts
@@ -1,13 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-/**
- * Extract Command: Extract RuyiSDK Package from source
- *
- * Provides user-facing command for:
- * - Listing all available source packages
- * - Letting user select a package to extract
- * - Extracting the selected package to the current directory
- */
-
 import * as path from 'path'
 import * as vscode from 'vscode'
 
@@ -15,9 +6,6 @@ import { createProgressTracker, parseNDJSON } from '../common/helpers'
 import ruyi from '../ruyi'
 import type { RuyiListOutput } from '../ruyi/types'
 
-/**
- * Parse the NDJSON output of `ruyi --porcelain list` to get source packages with versions.
- */
 interface SourcePackage {
   label: string
   value: string

--- a/src/packages/index.ts
+++ b/src/packages/index.ts
@@ -1,27 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-
 import * as vscode from 'vscode'
 
-import registerExtractCommand, { extractPackage } from './extract.command'
-import registerPackageInstallCommand, { installPackage } from './install.command'
+import registerExtractCommand from './extract.command'
+import registerInstallCommand from './install.command'
 import { PackagesTreeProvider } from './package-tree.provider'
 import { PackageService } from './package.service'
 import registerRefreshCommand from './refresh.command'
-import registerPackageUninstallCommand, { uninstallPackage } from './uninstall.command'
+import registerUninstallCommand from './uninstall.command'
 
-export {
-  registerPackageInstallCommand,
-  registerPackageUninstallCommand,
-  registerExtractCommand,
-  registerRefreshCommand,
-  PackagesTreeProvider,
-  PackageService,
-  installPackage,
-  uninstallPackage,
-  extractPackage,
-}
-
-export function registerPackagesModule(context: vscode.ExtensionContext): void {
+export default function registerPackagesModule(ctx: vscode.ExtensionContext) {
   const packageService = new PackageService()
   const packagesTreeProvider = new PackagesTreeProvider(packageService)
 
@@ -29,12 +16,12 @@ export function registerPackagesModule(context: vscode.ExtensionContext): void {
     treeDataProvider: packagesTreeProvider,
     showCollapseAll: true,
   })
-  context.subscriptions.push(packagesTreeView)
+  ctx.subscriptions.push(packagesTreeView)
 
   void packagesTreeProvider.refresh()
 
-  registerPackageInstallCommand(context)
-  registerPackageUninstallCommand(context)
-  registerRefreshCommand(context, packagesTreeProvider)
-  registerExtractCommand(context)
+  registerInstallCommand(ctx)
+  registerUninstallCommand(ctx)
+  registerRefreshCommand(ctx, packagesTreeProvider)
+  registerExtractCommand(ctx)
 }

--- a/src/packages/install.command.ts
+++ b/src/packages/install.command.ts
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-/**
- * Install Command: install packages with progress feedback
- */
-
 import * as vscode from 'vscode'
 
 import { createProgressTracker } from '../common/helpers'
@@ -70,7 +66,7 @@ export async function installPackage(name: string, version?: string): Promise<bo
   return success
 }
 
-export default function registerPackageInstallCommand(ctx: vscode.ExtensionContext) {
+export default function registerInstallCommand(ctx: vscode.ExtensionContext) {
   const installDisposable = vscode.commands.registerCommand(
     'ruyi.packages.install',
     async (item: VersionItem) => {

--- a/src/packages/package-tree.provider.ts
+++ b/src/packages/package-tree.provider.ts
@@ -1,18 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-/**
- * PackagesTreeProvider
- *
- * Displays Ruyi packages in a tree view with the following hierarchy:
- * - Category (toolchain, source, emulator, etc.)
- *   - Package (e.g., llvm-plct)
- *     - Version (e.g., 17.0.6-ruyi.20240511)
- *
- * Each version item shows:
- * - Installation status (installed/available)
- * - Version tags (latest, prerelease, no binary)
- * - Context menu for install/uninstall actions
- */
-
 import * as vscode from 'vscode'
 
 import { logger } from '../common/logger.js'

--- a/src/packages/package.service.ts
+++ b/src/packages/package.service.ts
@@ -1,16 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-/**
- * PackageService
- *
- * Provides package listing, parsing, and installation status tracking.
- *
- * Features:
- * - Retrieves all available packages via `ruyi list`
- * - Parses package information including categories, versions, and metadata
- * - Tracks installation status by querying `ruyi list -- porcelain --installed`
- * - Caches results to minimize CLI calls
- */
-
 import { parseNDJSON } from '../common/helpers'
 import { logger } from '../common/logger'
 import ruyi, { PACKAGE_CATEGORIES, type PackageCategory } from '../ruyi'

--- a/src/packages/refresh.command.ts
+++ b/src/packages/refresh.command.ts
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
-
 import * as vscode from 'vscode'
 
 import { PackagesTreeProvider } from './package-tree.provider'
 
 export default function registerRefreshCommand(
-  context: vscode.ExtensionContext,
+  ctx: vscode.ExtensionContext,
   provider: PackagesTreeProvider,
 ) {
-  const refreshDisposable = vscode.commands.registerCommand(
+  const disposable = vscode.commands.registerCommand(
     'ruyi.packages.refresh',
     async () => {
       await vscode.window.withProgress(
@@ -24,5 +23,5 @@ export default function registerRefreshCommand(
     },
   )
 
-  context.subscriptions.push(refreshDisposable)
+  ctx.subscriptions.push(disposable)
 }

--- a/src/packages/uninstall.command.ts
+++ b/src/packages/uninstall.command.ts
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-/**
- * Uninstall Command: uninstall packages with confirmation
- */
-
 import * as vscode from 'vscode'
 
 import ruyi from '../ruyi'
@@ -67,7 +63,7 @@ export async function uninstallPackage(name: string, version?: string): Promise<
   return success
 }
 
-export default function registerPackageUninstallCommand(ctx: vscode.ExtensionContext) {
+export default function registerUninstallCommand(ctx: vscode.ExtensionContext) {
   const uninstallDisposable = vscode.commands.registerCommand(
     'ruyi.packages.uninstall',
     async (item: VersionItem) => {


### PR DESCRIPTION
## Summary by Sourcery

Unify the packages module’s export style and streamline command registration integration with the extension.

Enhancements:
- Switch the packages module to a default export and update imports to match the unified export style.
- Rename install/uninstall command registration functions and their imports for consistent naming across the packages subsystem.
- Simplify refresh command registration by standardizing parameter naming and disposable handling.