### PR TITLE
refactor(telemetry): unify export style

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,7 +36,7 @@ import { logger } from './common/logger'
 import registerHomeModule from './home'
 import registerNewsModule from './news'
 import registerPackagesModule from './packages'
-import { registerTelemetryModule } from './telemetry'
+import registerTelemetryModule from './telemetry'
 
 export function activate(context: vscode.ExtensionContext) {
   // Register configuration service

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -2,12 +2,12 @@
 
 import * as vscode from 'vscode'
 
-import { registerTelemetryCommands } from './telemetry.command'
+import registerTelemetryCommands from './telemetry.command'
 import { telemetryService } from './telemetry.service'
 
-export function registerTelemetryModule(context: vscode.ExtensionContext): void {
-  registerTelemetryCommands(context)
-  context.subscriptions.push(telemetryService)
+export default function registerTelemetryModule(ctx: vscode.ExtensionContext) {
+  registerTelemetryCommands(ctx)
+  ctx.subscriptions.push(telemetryService)
 
   telemetryService.syncFromConfiguration().catch((err) => {
     vscode.window.showErrorMessage(`Failed to initialize telemetry: ${err instanceof Error ? err.message : String(err)}`)
@@ -15,4 +15,3 @@ export function registerTelemetryModule(context: vscode.ExtensionContext): void 
 }
 
 export { promptForTelemetryConfiguration } from './telemetry.command'
-export { telemetryService } from './telemetry.service'

--- a/src/telemetry/telemetry.command.ts
+++ b/src/telemetry/telemetry.command.ts
@@ -7,8 +7,8 @@ import * as vscode from 'vscode'
 
 import { telemetryService } from './telemetry.service'
 
-export function registerTelemetryCommands(context: vscode.ExtensionContext): void {
-  context.subscriptions.push(
+export default function registerTelemetryCommands(ctx: vscode.ExtensionContext) {
+  ctx.subscriptions.push(
     vscode.commands.registerCommand('ruyi.telemetry.configure', async () => {
       await promptForTelemetryConfiguration()
     }),


### PR DESCRIPTION
## Summary by Sourcery

Unify the telemetry module’s export style to use default exports for the module initializer and command registration, and update consumers accordingly.

Enhancements:
- Convert telemetry module and command registration functions to default exports for consistent module export style.
- Adjust telemetry module initialization to use a concise default-exported function signature and context parameter naming.
- Remove now-redundant named export of the telemetry service from the telemetry index.