### PR TITLE
fix(telemetry): refines telemetry configuration logic and adds manual command

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,11 @@
         "command": "ruyi.manageRuyiPath",
         "title": "Manage RuyiSDK Path",
         "category": "Ruyi"
+      },
+      {
+        "command": "ruyi.telemetry.configure",
+        "title": "Configure Telemetry Settings",
+        "category": "Ruyi"
       }
     ],
     "menus": {

--- a/src/commands/detect.ts
+++ b/src/commands/detect.ts
@@ -11,7 +11,6 @@ import * as semver from 'semver'
 import { configuration } from '../common/configuration'
 import { logger } from '../common/logger.js'
 import ruyi, { resolveRuyi } from '../ruyi'
-import { promptForTelemetryConfiguration } from '../telemetry'
 
 interface GitHubRelease {
   tag_name: string
@@ -87,11 +86,6 @@ export default function registerDetectCommand(context: vscode.ExtensionContext) 
         vscode.commands.executeCommand('ruyi.install')
       }
       return
-    }
-
-    if (configuration.telemetryEnabled === undefined) {
-      // Prompt user to configure telemetry settings
-      await promptForTelemetryConfiguration()
     }
 
     const version = await ruyi.version()

--- a/src/common/configuration.ts
+++ b/src/common/configuration.ts
@@ -50,7 +50,8 @@ class ConfigurationService implements vscode.Disposable {
   }
 
   public get telemetryEnabled(): boolean | undefined {
-    return this.get<boolean | undefined>(CONFIG_KEYS.TELEMETRY, undefined)
+    const inspect = this.config.inspect<boolean>(CONFIG_KEYS.TELEMETRY)
+    return inspect?.workspaceFolderValue ?? inspect?.workspaceValue ?? inspect?.globalValue
   }
 
   public async setTelemetry(enabled: boolean): Promise<void> {

--- a/src/telemetry/telemetry.service.ts
+++ b/src/telemetry/telemetry.service.ts
@@ -12,8 +12,9 @@ import * as vscode from 'vscode'
 import { configuration } from '../common/configuration'
 import { CONFIG_KEYS } from '../common/constants'
 import { fullKey } from '../common/helpers'
-import ruyi from '../ruyi'
-import type { TelemetryStatus } from '../ruyi'
+import ruyi, { TelemetryStatus } from '../ruyi'
+
+import { promptForTelemetryConfiguration } from './telemetry.command'
 
 export class TelemetryService implements vscode.Disposable {
   private readonly disposable: vscode.Disposable
@@ -60,9 +61,16 @@ export class TelemetryService implements vscode.Disposable {
    * Mirrors the configuration value to the Ruyi CLI without modifying settings.
    */
   public async syncFromConfiguration(): Promise<boolean> {
-    const enabled = configuration.telemetryEnabled
+    let enabled = configuration.telemetryEnabled
     if (enabled === undefined) {
-      return false
+      await promptForTelemetryConfiguration()
+      enabled = configuration.telemetryEnabled
+    }
+
+    if (enabled === undefined) {
+      // User has not made a choice, so we can't sync anything.
+      // Return true to indicate that we're not in an error state.
+      return true
     }
 
     return this.applyTelemetry(enabled)


### PR DESCRIPTION
## Summary by Sourcery

Refine telemetry configuration handling and add a manual command to configure telemetry settings.

New Features:
- Add a VS Code command to manually configure telemetry settings from the command palette.

Bug Fixes:
- Ensure telemetry sync prompts for configuration when unset instead of failing and treats no user choice as a non-error state.

Enhancements:
- Derive telemetry configuration from the most specific defined scope (workspace folder, workspace, or global) instead of using a simple config getter.
- Remove redundant telemetry configuration prompting from the detect command so telemetry is handled centrally by the telemetry service.