### PR TITLE
fix: move RuyiSDK status to the left of venv status

### DIFF
--- a/src/commands/venv/detect.ts
+++ b/src/commands/venv/detect.ts
@@ -27,7 +27,7 @@ export default function registerDetectAllVenvsCommand(
   // Create status bar item for venv management
   const venvStatusBarItem = vscode.window.createStatusBarItem(
     vscode.StatusBarAlignment.Left,
-    1000,
+    100,
   )
   venvStatusBarItem.text = '$(circle-slash) No Active Venv'
   venvStatusBarItem.tooltip = 'Manage Ruyi Virtual Environments'

--- a/src/setup/manage.service.ts
+++ b/src/setup/manage.service.ts
@@ -140,7 +140,7 @@ export class ManageService implements vscode.Disposable {
     this.initialized = true
     this.statusBarItem = vscode.window.createStatusBarItem(
       vscode.StatusBarAlignment.Left,
-      100,
+      1000,
     )
     this.statusBarItem.command = 'ruyi.setup.manage'
     this.statusBarItem.text = '$(tools) <No RuyiSDK>'


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Reorder VS Code status bar priorities by lowering the venv status item priority and raising the RuyiSDK status item priority to change their left-side ordering.