### PR TITLE
ci: trigger release on any tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: Publish Extension
 on:
   push:
     tags:
-      - v*
+      - '*'
 
 jobs:
   publish-extension:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Broaden release workflow trigger to fire on all tag pushes