### PR TITLE
fix: improve toolchain and emulator installation

### DIFF
--- a/src/setup/setup.command.ts
+++ b/src/setup/setup.command.ts
@@ -99,6 +99,8 @@ export function registerInstallCommand(ctx: vscode.ExtensionContext): void {
     if (choice !== 'Install') return
 
     const promptReload = async (methodLabel: string, version: string) => {
+      // Refresh package management module after successful installation
+      await vscode.commands.executeCommand('ruyi.packages.refresh')
       const action = await vscode.window.showInformationMessage(
         `Ruyi installed via ${methodLabel}: ${version}`,
         'Reload Window',


### PR DESCRIPTION
This pull request improves the workflow for creating virtual environments (venvs) and installing required toolchains or emulators in the extension. The main focus is on providing a smoother and clearer user experience when a required toolchain or emulator is not installed, including prompting the user to install missing dependencies, handling installation success or failure, and ensuring the package list is refreshed after installation.

User experience improvements for venv creation:

* When a required toolchain or emulator is not installed during venv creation (`src/commands/venv/create.ts`), the user is now prompted to install it with clearer options ("Install" or "Cancel"). If installation succeeds, the package list is refreshed and the process continues; if it fails or is cancelled, the venv creation is aborted with an appropriate message. [[1]](diffhunk://#diff-df5bfc6aac10bc5fb35093eb8adb8a79dc8b04df6a61544a81c78dd763422a4aL112-L123) [[2]](diffhunk://#diff-df5bfc6aac10bc5fb35093eb8adb8a79dc8b04df6a61544a81c78dd763422a4aL190-L201)
* The obsolete `terminated` flag and related logic were removed, simplifying the control flow for aborting venv creation.

Package management refresh:

* After installing a toolchain, emulator, or the main Ruyi package, the package list is refreshed by executing the `ruyi.packages.refresh` command to ensure the latest state is reflected in the UI (`src/commands/venv/create.ts`, `src/setup/setup.command.ts`). [[1]](diffhunk://#diff-df5bfc6aac10bc5fb35093eb8adb8a79dc8b04df6a61544a81c78dd763422a4aL112-L123) [[2]](diffhunk://#diff-df5bfc6aac10bc5fb35093eb8adb8a79dc8b04df6a61544a81c78dd763422a4aL190-L201) [[3]](diffhunk://#diff-a363dae0e69096f63f59fe3e329aea8d6127d9e85b17c61feb61bd113a0bee6eR102-R103)