### PR TITLE
fix: enhance venv detection and management

### DIFF
--- a/src/commands/venv/create.ts
+++ b/src/commands/venv/create.ts
@@ -241,10 +241,11 @@ export default function registerCreateNewVenvCommand(
     })
     if (name === undefined) return
 
-    // Input path, default to ./ruyi-venv/
+    // Input path, default to ./ruyi-venv-{profile}
+    const suggestedPath = `./ruyi-venv-${profile.replace(/\s+/g, '-')}`
     const path = await vscode.window.showInputBox({
       placeHolder: 'Path to create the new venv',
-      value: './ruyi-venv',
+      value: suggestedPath,
       validateInput: (value) => {
         if (!value || value.trim().length === 0) {
           return 'Path cannot be empty'

--- a/src/commands/venv/create.ts
+++ b/src/commands/venv/create.ts
@@ -36,11 +36,17 @@ export default function registerCreateNewVenvCommand(
 
     // Show quick pick for profile
     const allProfiles = await getProfiles()
-    const profile = await vscode.window.showQuickPick(
-      Object.keys(allProfiles), {
-        placeHolder: 'Select a profile for the new venv',
-      })
-    if (!profile) return
+    const profileItems = Object.entries(allProfiles).map(([label, raw]) => ({
+      label: label,
+      description: raw !== label ? raw : undefined,
+    }))
+
+    const pickedProfile = await vscode.window.showQuickPick(profileItems, {
+      placeHolder: 'Select a profile for the new venv',
+      matchOnDescription: true,
+    })
+    if (!pickedProfile) return
+    const profile = pickedProfile.label
 
     // Show quick pick for toolchain
     const allToolchains = await getToolchains()
@@ -235,10 +241,10 @@ export default function registerCreateNewVenvCommand(
     })
     if (name === undefined) return
 
-    // Input path, default to ./myhone-venv/
+    // Input path, default to ./ruyi-venv/
     const path = await vscode.window.showInputBox({
       placeHolder: 'Path to create the new venv',
-      value: `./myhone-venv`,
+      value: './ruyi-venv',
       validateInput: (value) => {
         if (!value || value.trim().length === 0) {
           return 'Path cannot be empty'

--- a/src/commands/venv/manageCurrentVenv.ts
+++ b/src/commands/venv/manageCurrentVenv.ts
@@ -8,12 +8,15 @@
  * Also detects when the user manually runs 'ruyi-deactivate' or 'source mypath/ruyi-activate' in the terminal.
  */
 
+import * as path from 'path'
 import * as vscode from 'vscode'
+
+import { getWorkspaceFolderPath } from '../../common/helpers'
 
 import { venvTree } from './detect'
 
 let ruyiTerminal: vscode.Terminal | null
-export let currentVenv: string | null = null
+export let currentVenv: string | null = null // absolute path
 
 // Watch for terminal close event to reset currentVenv and ruyiTerminal
 export default function registerTerminalHandlerCommand(context: vscode.ExtensionContext) {
@@ -43,9 +46,18 @@ export default function registerTerminalHandlerCommand(context: vscode.Extension
         else if (commandLine.startsWith('source ') && commandLine.includes('/bin/ruyi-activate')) {
           const match = commandLine.match(/source\s+(.+?)\/bin\/ruyi-activate/)
           if (match) {
-            currentVenv = match[1]
-            venvTree.setCurrentVenv(currentVenv, null)
-            vscode.window.showInformationMessage(`Ruyi venv activated: ${currentVenv}`)
+            try {
+              const workspaceRoot = getWorkspaceFolderPath()
+              const abs = path.isAbsolute(match[1])
+                ? match[1]
+                : path.resolve(workspaceRoot, match[1])
+              currentVenv = abs
+              venvTree.setCurrentVenv(currentVenv, path.basename(abs))
+              vscode.window.showInformationMessage(`Ruyi venv activated: ${currentVenv}`)
+            }
+            catch {
+              // Ignore if workspace is not available
+            }
           }
         }
       }
@@ -54,10 +66,25 @@ export default function registerTerminalHandlerCommand(context: vscode.Extension
 }
 
 // Get or create the Ruyi terminal for venv activation, assigning a venv path to it.
-export function manageRuyiTerminal(venvPath: string | null) {
+export function manageRuyiTerminal(venvPath: string | null, venvName?: string) {
+  let workspaceRoot: string
+  try {
+    workspaceRoot = getWorkspaceFolderPath()
+  }
+  catch {
+    vscode.window.showWarningMessage('Open a workspace folder before activating a Ruyi venv.')
+    return
+  }
+
+  const absPath = venvPath ? path.resolve(workspaceRoot, venvPath) : null
+
   if (!ruyiTerminal) {
-    if (venvPath) {
-      ruyiTerminal = vscode.window.createTerminal({ name: 'Ruyi Venv Terminal', shellPath: '/bin/bash' })
+    if (absPath) {
+      ruyiTerminal = vscode.window.createTerminal({
+        name: 'Ruyi Venv Terminal',
+        shellPath: '/bin/bash',
+        cwd: workspaceRoot,
+      })
       ruyiTerminal.show()
     }
     else {
@@ -67,25 +94,34 @@ export function manageRuyiTerminal(venvPath: string | null) {
       return
     }
   }
-  if (venvPath === null) {
+
+  if (absPath === null) {
     // Deactivate current venv
     ruyiTerminal.sendText('ruyi-deactivate')
+    currentVenv = null
+    venvTree.setCurrentVenv(null, null)
+    return
   }
-  else if (venvPath !== currentVenv) {
-    // Activate new venv
-    if (currentVenv) {
-      ruyiTerminal.sendText('ruyi-deactivate')
-      // Sleep for a short moment to ensure deactivation completes
-      setTimeout(() => {
-        ruyiTerminal!.sendText(`source ${venvPath}/bin/ruyi-activate`)
-      }, 100)
-    }
-    else {
-      ruyiTerminal.sendText(`source ${venvPath}/bin/ruyi-activate`)
-    }
+
+  if (currentVenv && path.normalize(absPath) === path.normalize(currentVenv)) {
+    // Toggle: deactivate same venv
+    ruyiTerminal.sendText('ruyi-deactivate')
+    currentVenv = null
+    venvTree.setCurrentVenv(null, null)
+    return
   }
-  // Trying to activate the same venv, although shouldn't reach here due to earlier check.
+
+  // Activate new venv
+  if (currentVenv) {
+    ruyiTerminal.sendText('ruyi-deactivate')
+    setTimeout(() => {
+      ruyiTerminal?.sendText(`source "${absPath}/bin/ruyi-activate"`)
+    }, 100)
+  }
   else {
-    vscode.window.showInformationMessage(`Ruyi venv already active: ${venvPath}`)
+    ruyiTerminal.sendText(`source "${absPath}/bin/ruyi-activate"`)
   }
+
+  currentVenv = absPath
+  venvTree.setCurrentVenv(absPath, venvName ?? path.basename(absPath))
 }

--- a/src/commands/venv/switch.ts
+++ b/src/commands/venv/switch.ts
@@ -12,7 +12,7 @@ import * as vscode from 'vscode'
 
 import { VenvTreeItem } from '../../features/venv/VenvTree'
 
-import { manageRuyiTerminal, currentVenv } from './manageCurrentVenv'
+import { manageRuyiTerminal } from './manageCurrentVenv'
 
 export default function registerSwitchFromVenvsCommand(
   context: vscode.ExtensionContext) {
@@ -22,8 +22,7 @@ export default function registerSwitchFromVenvsCommand(
       return
     }
     // Manage the Ruyi terminal for venv activation/deactivation
-    const venvPath = `./${venv.venvPath}`
-    manageRuyiTerminal(venvPath === currentVenv ? null : venvPath)
+    manageRuyiTerminal(venv.venvPath, venv.name)
 
     // Refresh the venv tree view to reflect the current active venv
     await vscode.commands.executeCommand('ruyi.venv.refresh')

--- a/src/features/venv/GetProfiles.ts
+++ b/src/features/venv/GetProfiles.ts
@@ -14,10 +14,13 @@ export function readStdoutP(stdout: string): Record<string, string> {
   const lines = stdout.split(/\r?\n/)
   for (const line of lines) {
     if (!line.trim()) continue // skip empty lines
-    // Use the entire line as the key, and the line without parentheses as the value
-    const key = line
-    const value = key.replace(/\([^()]*\)/g, '').trim()
-    dict[key] = value
+    const raw = line
+    // Remove any parenthetical annotations, e.g., "(needs quirks: {'xthead'})"
+    const label = raw.replace(/\([^()]*\)/g, '').trim()
+    if (!label) continue
+
+    // Map cleaned name -> raw line so UI can show raw in description
+    dict[label] = raw
   }
   // Sort the dictionary by keys
   const sortedDict: Record<string, string> = {}


### PR DESCRIPTION
This pull request makes several improvements and bug fixes to the virtual environment (venv) management commands and UI for the extension. The main focus is on consistently handling absolute venv paths, improving the venv selection UI, and ensuring correct workspace-relative path resolution throughout the codebase.

**Key changes include:**

### Path Handling and Consistency

* All venv paths are now handled as absolute paths internally, reducing ambiguity and preventing path-related bugs. Functions that activate or deactivate venvs now consistently resolve relative paths using the workspace root. (`src/commands/venv/manageCurrentVenv.ts`, `src/commands/venv/detect.ts`, `src/features/venv/VenvTree.ts`, `src/commands/venv/switch.ts`) [[1]](diffhunk://#diff-71766eaeefb4ee86fbceca2331b8a9b3bf516b88182c18e52fcf970833fc1caaR11-R19) [[2]](diffhunk://#diff-71766eaeefb4ee86fbceca2331b8a9b3bf516b88182c18e52fcf970833fc1caaL46-R87) [[3]](diffhunk://#diff-71766eaeefb4ee86fbceca2331b8a9b3bf516b88182c18e52fcf970833fc1caaL70-R126) [[4]](diffhunk://#diff-28b25a9ee95838caa5f02ec4e77337b7dea9d994823ba4abb2d21a7f62c74a60R18-R22) [[5]](diffhunk://#diff-28b25a9ee95838caa5f02ec4e77337b7dea9d994823ba4abb2d21a7f62c74a60R50-R66) [[6]](diffhunk://#diff-f6ae052b880f476b53e9dddcbc6e55c40b1b38571dd591721fbb85ee445fbdadL18-R18) [[7]](diffhunk://#diff-f6ae052b880f476b53e9dddcbc6e55c40b1b38571dd591721fbb85ee445fbdadR30) [[8]](diffhunk://#diff-f6ae052b880f476b53e9dddcbc6e55c40b1b38571dd591721fbb85ee445fbdadL70-R73) [[9]](diffhunk://#diff-f6ae052b880f476b53e9dddcbc6e55c40b1b38571dd591721fbb85ee445fbdadL98-R115) [[10]](diffhunk://#diff-42b7fb1da3761329af2252a1f9856cdbdea715046821087b7ef7bec3b056944aL15-R15) [[11]](diffhunk://#diff-42b7fb1da3761329af2252a1f9856cdbdea715046821087b7ef7bec3b056944aL25-R25)

* The venv tree view now displays venv paths relative to the workspace root for better readability, while still tracking the absolute path internally. (`src/features/venv/VenvTree.ts`)

### UI/UX Improvements

* The venv profile selection UI now shows both the cleaned profile name and the raw profile line (including annotations) in the quick pick, making it easier for users to distinguish between similar profiles. (`src/commands/venv/create.ts`, `src/features/venv/GetProfiles.ts`) [[1]](diffhunk://#diff-df5bfc6aac10bc5fb35093eb8adb8a79dc8b04df6a61544a81c78dd763422a4aL39-R49) [[2]](diffhunk://#diff-1e56ed59433999f7c38c6cdafd637e2430a49fb2f5296bf59470b4783c2dd6a9L17-R23)

* The default directory for new venv creation has been updated from `./myhone-venv` to `./ruyi-venv` to reflect the current project naming. (`src/commands/venv/create.ts`)

### Robustness and Error Handling

* Added checks and error handling to ensure that venv operations gracefully handle cases where no workspace is open, preventing errors and providing appropriate user feedback. (`src/commands/venv/detect.ts`, `src/commands/venv/manageCurrentVenv.ts`) [[1]](diffhunk://#diff-28b25a9ee95838caa5f02ec4e77337b7dea9d994823ba4abb2d21a7f62c74a60R50-R66) [[2]](diffhunk://#diff-71766eaeefb4ee86fbceca2331b8a9b3bf516b88182c18e52fcf970833fc1caaL46-R87)

* Improved logic for toggling venv activation: activating the same venv again will now deactivate it, and all internal state is kept in sync. (`src/commands/venv/manageCurrentVenv.ts`)

## Summary by Sourcery

Improve virtual environment activation, detection, and display to use consistent absolute paths and provide clearer, more robust UX in the VS Code extension.

Bug Fixes:
- Ensure venv activation and detection consistently resolve venv paths against the workspace root and treat them as absolute paths.
- Avoid errors when running venv commands without an open workspace by guarding workspace-dependent operations.

Enhancements:
- Show venv paths in the tree view relative to the workspace while tracking absolute paths internally and highlighting the active venv reliably.
- Allow re-invoking activation of the currently active venv to toggle it off, keeping internal state and UI in sync.
- Improve the venv profile picker by using cleaned profile names as labels and displaying the raw profile line as a description to disambiguate similar profiles.
- Update the default directory name for new venv creation from ./myhone-venv to ./ruyi-venv for consistency with current project naming.