### PR TITLE
refactor(venv): streamline venv creation and detection by removing unnecessary prompts and simplifying name handling

### DIFF
--- a/src/commands/venv/create.ts
+++ b/src/commands/venv/create.ts
@@ -234,13 +234,6 @@ export default function registerCreateNewVenvCommand(
     }
     else emulator = null
 
-    // Input name, default to profile name
-    const name = await vscode.window.showInputBox({
-      placeHolder: 'Name of the new venv',
-      value: profile, // Default value set to profile name
-    })
-    if (name === undefined) return
-
     // Input path, default to ./ruyi-venv-{profile}
     const suggestedPath = `./ruyi-venv-${profile.replace(/\s+/g, '-')}`
     const path = await vscode.window.showInputBox({
@@ -290,7 +283,7 @@ export default function registerCreateNewVenvCommand(
     await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,
-        title: `Creating venv "${name}"`,
+        title: 'Creating venv',
         cancellable: false,
       },
       async (progress) => {
@@ -303,7 +296,6 @@ export default function registerCreateNewVenvCommand(
           .cwd(getWorkspaceFolderPath())
           .onProgress(onProgress)
           .venv(profile, path, {
-            name,
             toolchain: toolchains,
             emulator: emulator ?? undefined,
             sysrootFrom,

--- a/src/features/venv/DetectforVenv.ts
+++ b/src/features/venv/DetectforVenv.ts
@@ -9,7 +9,7 @@
  * which contains a "ruyi-activate" file,
  * it is considered a Ruyi venv.
  * Under this circumstance, we will record the relative path,
- * as well as the $1 of the "RUYI_VENV_PROMPT=$1" line in the "ruyi-activate" file.
+ * and use the folder name (basename) as the venv name.
  * We can return multiple venvs if found.
  */
 
@@ -71,13 +71,9 @@ export async function detectVenv(): Promise<string[][]> {
       try {
         const activateUri = vscode.Uri.file(activatePath)
         await vscode.workspace.fs.stat(activateUri) // ensure the existence of activatePath. not exist -> exception
-        // Read the ruyi-activate file to find the RUYI_VENV_PROMPT line
-        const activateContent = Buffer.from(await vscode.workspace.fs.readFile(activateUri)).toString('utf-8')
-        const promptLine = activateContent.split('\n')
-          .find(line => line.includes('RUYI_VENV_PROMPT='))
-        if (promptLine) {
-          foundVenvs.push([dir, promptLine.split('=')[1].trim()])
-        }
+        // Use the basename of the venv directory as the venv name
+        const venvName = path.basename(dir)
+        foundVenvs.push([dir, venvName])
       }
       catch {
         // pass

--- a/src/features/venv/VenvTree.ts
+++ b/src/features/venv/VenvTree.ts
@@ -7,7 +7,6 @@
  *
  * Each venv item shows:
  * - Venv name
- * - Venv path relative to workspace
  */
 
 import * as paths from 'path'
@@ -91,7 +90,7 @@ export class VenvTreeProvider implements
       const normalizedPath = paths.normalize(this._currentVenvPath)
       const displayName = this._currentVenvName || paths.basename(normalizedPath) || 'Unknown Venv'
       this._statusBarItem.text = `$(check) ${displayName}`
-      this._statusBarItem.tooltip = `Active Ruyi Venv: ${displayName}\nPath: ${this._currentVenvPath}`
+      this._statusBarItem.tooltip = `Active Ruyi Venv: ${displayName}`
     }
     else {
       this._statusBarItem.text = '$(circle-slash) No Active Venv'
@@ -157,10 +156,6 @@ export class VenvTreeItem extends vscode.TreeItem {
       this.contextValue = 'ruyiVenv.placeholder'
     }
     else {
-      this.description = `at ./${venvPath}`
-      this.tooltip = isCurrentVenv
-        ? `${name}\nPath: ${venvPath}\n✓ Currently Active`
-        : `${name}\nPath: ${venvPath}`
       if (isCurrentVenv) {
         this.iconPath = new vscode.ThemeIcon('check', new vscode.ThemeColor('testing.iconPassed'))
         this.contextValue = 'ruyiVenv.current'

--- a/src/ruyi/index.ts
+++ b/src/ruyi/index.ts
@@ -108,7 +108,6 @@ export interface SelfCleanOptions {
 }
 
 export interface VenvOptions {
-  name?: string
   toolchain?: string | string[]
   emulator?: string
   withSysroot?: boolean
@@ -505,9 +504,6 @@ export class Ruyi {
   ): Promise<RuyiResult> {
     const args = ['venv']
 
-    if (options?.name) {
-      args.push('--name', options.name)
-    }
     if (options?.toolchain) {
       const toolchains = Array.isArray(options.toolchain) ? options.toolchain : [options.toolchain]
       toolchains.forEach(tc => args.push('--toolchain', tc))


### PR DESCRIPTION
Fix #99 This pull request simplifies and standardizes the handling of virtual environment (venv) names in the extension. The main change is to consistently use the directory name (basename) as the venv name, removing the need to parse or input custom names. As a result, related UI elements and command parameters have been streamlined, reducing complexity and potential user confusion.

**Venv Name Handling Simplification:**

* The venv name is now always derived from the folder name (basename) instead of being input by the user or parsed from the `ruyi-activate` file. (`src/features/venv/DetectforVenv.ts`, [[1]](diffhunk://#diff-4ee182ab17928a761934140fa2cd2b358ab2618955a9f6a2abb9f84337ee6a57L12-R12) [[2]](diffhunk://#diff-4ee182ab17928a761934140fa2cd2b358ab2618955a9f6a2abb9f84337ee6a57L74-R76)
* The option to input a custom venv name during creation has been removed from the command UI. (`src/commands/venv/create.ts`, [src/commands/venv/create.tsL237-L243](diffhunk://#diff-df5bfc6aac10bc5fb35093eb8adb8a79dc8b04df6a61544a81c78dd763422a4aL237-L243))
* The `name` property has been removed from the `VenvOptions` interface and is no longer passed to the backend when creating a venv. (`src/ruyi/index.ts`, [[1]](diffhunk://#diff-c5d789523d7785227b091d6ed0972278b784d4065cf80261fbba3bbae124fef7L111) [[2]](diffhunk://#diff-c5d789523d7785227b091d6ed0972278b784d4065cf80261fbba3bbae124fef7L508-L510)
* The progress notification when creating a venv no longer includes the venv name, reflecting the removal of custom naming. (`src/commands/venv/create.ts`, [[1]](diffhunk://#diff-df5bfc6aac10bc5fb35093eb8adb8a79dc8b04df6a61544a81c78dd763422a4aL293-R286) [[2]](diffhunk://#diff-df5bfc6aac10bc5fb35093eb8adb8a79dc8b04df6a61544a81c78dd763422a4aL306)

**UI and Tooltip Adjustments:**

* Tooltips and descriptions in the venv tree and status bar have been updated to remove path details and references to custom names, further simplifying the user interface. (`src/features/venv/VenvTree.ts`, [[1]](diffhunk://#diff-f6ae052b880f476b53e9dddcbc6e55c40b1b38571dd591721fbb85ee445fbdadL10) [[2]](diffhunk://#diff-f6ae052b880f476b53e9dddcbc6e55c40b1b38571dd591721fbb85ee445fbdadL94-R93) [[3]](diffhunk://#diff-f6ae052b880f476b53e9dddcbc6e55c40b1b38571dd591721fbb85ee445fbdadL160-L163)

## Summary by Sourcery

Standardize virtual environment naming to always use the venv folder basename and simplify related UI and command handling.

Enhancements:
- Derive detected venv names from the venv directory basename instead of parsing the ruyi-activate file.
- Remove the custom venv name input and name-dependent progress text from the venv creation command, relying solely on the selected path/profile.
- Drop the optional name field from VenvOptions and its propagation to the backend CLI, simplifying venv creation options.
- Simplify venv status bar tooltip and tree item presentation by removing path and custom-name details.