### PR TITLE
docs: add VSCode Marketplace links; adjust screenshot to correct preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 The official VS Code extension for RuyiSDK, providing RISC-V developers with an all-in-one development environment management experience.
 
-<img width="2516" height="1566" alt="Image" src="screenshot.png" />
+<img width="1000" alt="Image" src="screenshot.png" />
+
+Install from [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=RuyiSDK.ruyisdk-vscode-extension).
 
 ## Features
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -4,7 +4,9 @@
 
 RuyiSDK 官方 VS Code 扩展，为 RISC-V 开发者提供一站式的开发环境管理体验。
 
-<img width="2516" height="1566" alt="Image" src="screenshot.png" />
+<img width="1000" alt="Image" src="screenshot.png" />
+
+从 [Visual Studio 市场](https://marketplace.visualstudio.com/items?itemName=RuyiSDK.ruyisdk-vscode-extension)安装本插件。
 
 ## 功能亮点
 


### PR DESCRIPTION
The screenshot of https://github.dev/ruyisdk/ruyisdk-vscode-extension before this change:

<img width="800" alt="screenshot of the distorted image in VSCode Online" src="https://github.com/user-attachments/assets/00054fc6-0d0b-4c34-984d-f033cde40e25" />

Recreated from https://github.com/ruyisdk/ruyisdk-vscode-extension/pull/110 due to Git mis-operation.

## Summary by Sourcery

Update README documentation for the RuyiSDK VS Code extension with corrected screenshot display and marketplace installation links.

Documentation:
- Adjust the README screenshots to use a smaller width for correct rendering in online VS Code previews.
- Add Visual Studio Marketplace installation links to both English and Chinese READMEs.