### PR TITLE
fix: sync read status with ruyi CLI using porcelain mode

### DIFF
--- a/src/news/news-webview.provider.ts
+++ b/src/news/news-webview.provider.ts
@@ -42,6 +42,7 @@ export class NewsWebviewProvider {
   async showCards(): Promise<void> {
     if (this.panel) {
       this.panel.reveal()
+      await this.updateContent()
       return
     }
 

--- a/src/ruyi/index.ts
+++ b/src/ruyi/index.ts
@@ -95,6 +95,7 @@ export interface ListOptions {
 
 export interface NewsListOptions {
   newOnly?: boolean
+  porcelain?: boolean
 }
 
 export interface SelfCleanOptions {
@@ -558,7 +559,13 @@ export class Ruyi {
    * List news items
    */
   async newsList(options?: NewsListOptions): Promise<RuyiResult> {
-    const args = ['news', 'list']
+    const args: string[] = []
+
+    if (options?.porcelain) {
+      args.push('--porcelain')
+    }
+
+    args.push('news', 'list')
 
     if (options?.newOnly) {
       args.push('--new')


### PR DESCRIPTION
## Summary by Sourcery

Synchronize news read status and summaries with the ruyi CLI using its porcelain JSON output and simplify local caching of news items.

New Features:
- Add support for parsing ruyi news porcelain JSON output with language selection to populate news items with titles, summaries, and read status.

Bug Fixes:
- Align local news read status and summaries with the ruyi CLI backend instead of recomputing them from separate reads.
- Ensure the news webview refreshes its content when an existing panel is re-shown.

Enhancements:
- Simplify news fetching by preferring ruyi CLI output and falling back to the local cache while reducing redundant network calls and summary-fetching logic.
- Extend the ruyi client to support a porcelain mode flag for news listing requests.