### PR TITLE
feat(package): add outdated version tagging and sort versions

### DIFF
--- a/src/packages/package-tree.provider.ts
+++ b/src/packages/package-tree.provider.ts
@@ -268,6 +268,9 @@ export class VersionItem extends vscode.TreeItem {
 
   private buildDescription(): string {
     const tags: string[] = []
+    if (this.versionInfo.isOutdated) {
+      tags.push('outdated')
+    }
     if (this.versionInfo.isLatest) {
       tags.push('latest')
     }


### PR DESCRIPTION
This pull request introduces improvements to how package versions are managed and displayed, focusing on identifying and marking outdated versions and sorting them more reliably. The changes enhance user awareness of version status and improve the accuracy of version ordering.

Enhancements to package version management:

* Added a new `isOutdated` property to the `RuyiPackageVersion` interface to track whether a version is considered outdated.
* Updated the version sorting logic in the `PackageService` class to use semantic versioning (`semver`) for more accurate ordering, falling back to string comparison if parsing fails.
* Marked all but the latest three package versions as outdated by setting the `isOutdated` property accordingly after sorting.
* Imported the `semver` library in `package.service.ts` to enable semantic version sorting.

User interface improvements:

* Updated the `VersionItem` class so that the "outdated" tag is displayed for versions marked as outdated, improving visibility in the UI.

## Summary by Sourcery

Add support for marking and displaying outdated package versions based on semver-sorted version lists.

New Features:
- Introduce an isOutdated flag on package versions to indicate outdated releases.
- Display an "outdated" tag in the version tree view for versions marked as outdated.

Enhancements:
- Sort package versions using semantic versioning with a string comparison fallback, and automatically mark only the latest three versions as current.