### PR TITLE
feat: add outdated label to Ruyi installations in quick pick and mark installations as outdated

### DIFF
--- a/src/setup/manage.command.ts
+++ b/src/setup/manage.command.ts
@@ -41,8 +41,9 @@ async function promptManualInput(): Promise<void> {
 function buildQuickPickItems(installations: RuyiInstallation[]): RuyiPathQuickPickItem[] {
   const items = installations.map((installation) => {
     const versionSuffix = installation.version ? ` (${installation.version})` : ''
+    const outdatedLabel = installation.isOutdated ? ' $(warning) Outdated' : ''
     return {
-      label: `$(package) ${path.basename(installation.path)}${versionSuffix}`,
+      label: `$(package) ${path.basename(installation.path)}${versionSuffix}${outdatedLabel}`,
       description: path.dirname(installation.path),
       detail: installation.version ? `Version: ${installation.version}` : installation.path,
       targetPath: installation.path,


### PR DESCRIPTION
This pull request enhances the management of RuyiSDK installations by visually indicating outdated versions in the selection UI. The main changes introduce an `isOutdated` property to the installation objects, determine which installations are outdated (all but the latest three), and update the UI to display a warning icon for outdated installations.

**Outdated installation marking and UI indication:**

* Added an `isOutdated` property to the `RuyiInstallation` interface to track if an installation is outdated.
* Updated the `listAllInstallations` function to set `isOutdated` to `true` for all but the latest three installations with valid versions.
* Modified the quick pick UI in `promptManualInput` to append a warning icon and 'Outdated' label to installations marked as outdated.

## Summary by Sourcery

Indicate outdated RuyiSDK installations in the selection UI and track their status in installation metadata.

New Features:
- Track whether a RuyiSDK installation is outdated via a new isOutdated flag on installation records.
- Display a warning icon and 'Outdated' label for outdated RuyiSDK installations in the quick pick UI.

Enhancements:
- Determine and mark all but the latest three RuyiSDK installations with valid versions as outdated during installation discovery.