### PR TITLE
feat: enhance Ruyi installation management with GitHub release tagging

### DIFF
--- a/src/setup/manage.command.ts
+++ b/src/setup/manage.command.ts
@@ -41,8 +41,11 @@ async function promptManualInput(): Promise<void> {
 function buildQuickPickItems(installations: RuyiInstallation[]): RuyiPathQuickPickItem[] {
   const items = installations.map((installation) => {
     const versionSuffix = installation.version ? ` (${installation.version})` : ''
+    const tagsDisplay = installation.tags && installation.tags.length > 0
+      ? ` ${installation.tags.join(' ')}`
+      : ''
     return {
-      label: `$(package) ${path.basename(installation.path)}${versionSuffix}`,
+      label: `$(package) ${path.basename(installation.path)}${versionSuffix}${tagsDisplay}`,
       description: path.dirname(installation.path),
       detail: installation.version ? `Version: ${installation.version}` : installation.path,
       targetPath: installation.path,


### PR DESCRIPTION
This pull request enhances the RuyiSDK version management in the VSCode extension by integrating GitHub release data to provide richer version information and improve automatic selection logic. The main improvements include fetching release data from GitHub, tagging installations as "Prereleased" or "Outdated", and updating the UI and auto-selection logic to prefer the latest stable version.

**Integration with GitHub Release Data:**

* Added `fetchGitHubReleases` to retrieve all releases from GitHub and `determineVersionTags` to assign tags such as "Prereleased" and "Outdated" to RuyiSDK installations based on their version and release status.

* Modified `listAllInstallations` and `detectRuyiInstallation` to fetch GitHub releases and tag each installation accordingly, enriching the `RuyiInstallation` object with a `tags` property. [[1]](diffhunk://#diff-9be99e0acdf4b17d9469dd03937371ab348dae98d318ac92e9332d186784e922R159-R161) [[2]](diffhunk://#diff-9be99e0acdf4b17d9469dd03937371ab348dae98d318ac92e9332d186784e922R203-R209) [[3]](diffhunk://#diff-9be99e0acdf4b17d9469dd03937371ab348dae98d318ac92e9332d186784e922R239-R249)

**User Interface Improvements:**

* Updated the quick pick item label in `promptManualInput` to display version tags (e.g., "Prereleased", "Outdated") alongside the version, improving the clarity of installation status for users.

* Improved status bar display to show the full version string, including prerelease suffix, for better accuracy.

**Automatic Version Selection Logic:**

* Enhanced automatic selection logic to prefer the latest stable (non-prerelease) installation when clearing the Ruyi path or when updating the status bar, falling back to any available version if no stable version is found. [[1]](diffhunk://#diff-9be99e0acdf4b17d9469dd03937371ab348dae98d318ac92e9332d186784e922R297-R309) [[2]](diffhunk://#diff-9be99e0acdf4b17d9469dd03937371ab348dae98d318ac92e9332d186784e922R371-R383)

## Summary by Sourcery

Integrate GitHub release information into RuyiSDK installation management to improve version tagging, UI clarity, and automatic selection of stable installations.

New Features:
- Tag RuyiSDK installations with metadata such as prerelease and outdated status based on GitHub release data.
- Display version tags and full version strings in the VS Code UI for clearer visibility of installation status.
- Automatically prefer the latest stable RuyiSDK installation when clearing or auto-selecting the Ruyi path.

Enhancements:
- Extend Ruyi installation discovery and detection to fetch GitHub releases and enrich installation objects with parsed version and tag data.