### PR TITLE
build: bump version to 0.1.2-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ruyisdk-vscode-extension",
-  "version": "0.1.1",
+  "version": "0.1.2-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ruyisdk-vscode-extension",
-      "version": "0.1.1",
+      "version": "0.1.2-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "semver": "^7.7.3"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ruyisdk-vscode-extension",
   "displayName": "RuyiSDK",
   "description": "VS Code integration for the Ruyi package manager.",
-  "version": "0.1.1",
+  "version": "0.1.2-beta.1",
   "publisher": "RuyiSDK",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update package metadata to reflect version 0.1.2-beta.1 in package.json and lockfile.