### PR TITLE
refactor(venv): use structured profiles list from entity system

### DIFF
--- a/src/ruyi/index.ts
+++ b/src/ruyi/index.ts
@@ -390,10 +390,10 @@ export class Ruyi {
   }
 
   /**
-   * List all available profiles
+   * List all available profiles using entity command
    */
   async listProfiles(): Promise<RuyiResult> {
-    return runRuyi(['--porcelain', 'list', 'profiles'], this.options)
+    return runRuyi(['--porcelain', 'entity', 'list', '-t', 'profile-v1'], this.options)
   }
 
   // ============================================================================
@@ -728,4 +728,9 @@ export class Ruyi {
   }
 }
 
-export default new Ruyi()
+export default new Ruyi({
+  env: {
+    ...process.env,
+    RUYI_EXPERIMENTAL: '1',
+  },
+})

--- a/src/venv/create.command.ts
+++ b/src/venv/create.command.ts
@@ -80,9 +80,9 @@ export async function createVenvCommand(service: VenvService): Promise<void> {
 
   // 2. Select Profile
   const allProfiles = await service.getProfiles()
-  const profileItems = Object.entries(allProfiles).map(([label, raw]) => ({
+  const profileItems = Object.entries(allProfiles).map(([label, description]) => ({
     label,
-    description: raw !== label ? raw : undefined,
+    description,
   }))
 
   const pickedProfile = await vscode.window.showQuickPick(profileItems, {

--- a/src/venv/profile.helper.ts
+++ b/src/venv/profile.helper.ts
@@ -8,41 +8,66 @@
 
 import { logger } from '../common/logger'
 import ruyi from '../ruyi'
+import type { RuyiResult } from '../ruyi'
 
-import type { ProfilesMap } from './types'
+import type { ProfilesMap, RuyiProfile } from './types'
 
-export type { ProfilesMap }
+export type { ProfilesMap, RuyiProfile }
 
 /**
- * Parses the raw stdout from `ruyi list` command to extract profiles.
- * Cleans up parenthetical annotations and returns a sorted dictionary.
- *
- * @param stdout - Raw output from ruyi list command
- * @returns Sorted dictionary mapping cleaned profile names to raw lines
+ * Parse the JSON Lines output from entity list command into RuyiProfile array
  */
-export function parseProfiles(stdout: string): ProfilesMap {
-  const dict: Record<string, string> = {}
-  const lines = stdout.split(/\r?\n/)
-
-  for (const line of lines) {
-    if (!line.trim()) continue // skip empty lines
-
-    const raw = line
-    // Remove any parenthetical annotations, e.g., "(needs quirks: {'xthead'})" or "（需要特殊特性：{'xthead'}）"
-    const label = raw.replace(/[(\uff08][^()\uff08\uff09]*[)\uff09]/g, '').trim()
-    if (!label) continue
-
-    // Map cleaned name -> raw line so UI can show raw in description
-    dict[label] = raw
+function parseProfilesOutput(result: RuyiResult): RuyiProfile[] {
+  if (result.code !== 0) {
+    throw new Error(`Failed to list profiles: ${result.stderr}`)
   }
 
-  // Sort the dictionary by keys
-  const sortedDict: Record<string, string> = {}
-  Object.keys(dict).sort().forEach((key) => {
-    sortedDict[key] = dict[key]
-  })
+  const profiles: RuyiProfile[] = []
+  const lines = result.stdout.split(/\r?\n/).filter(line => line.trim())
 
-  return sortedDict
+  for (const line of lines) {
+    try {
+      const entity = JSON.parse(line)
+      const data = entity.data?.['profile-v1']
+      if (!data) continue
+
+      profiles.push({
+        id: data.id ?? entity.entity_id,
+        displayName: data.display_name ?? entity.display_name,
+        arch: data.arch ?? 'unknown',
+        neededToolchainQuirks: data.needed_toolchain_quirks ?? [],
+        toolchainCommonFlagsStr: data.toolchain_common_flags_str ?? '',
+      })
+    }
+    catch (err) {
+      logger.warn(`Failed to parse profile line: ${line}`, err)
+    }
+  }
+
+  // Sort by display name for consistent ordering
+  return profiles.sort((a, b) => a.displayName.localeCompare(b.displayName))
+}
+
+/**
+ * Converts structured RuyiProfile array to ProfilesMap format.
+ * Returns a map of display names to optional descriptions.
+ *
+ * @param profiles - Array of structured profile objects
+ * @returns Dictionary mapping profile display names to descriptions (or undefined)
+ */
+export function parseProfiles(profiles: RuyiProfile[]): ProfilesMap {
+  const dict: Record<string, string | undefined> = {}
+
+  for (const profile of profiles) {
+    // Build description only if quirks exist
+    const description = profile.neededToolchainQuirks.length > 0
+      ? `(needs quirks: ${profile.neededToolchainQuirks.join(', ')})`
+      : undefined
+
+    dict[profile.displayName] = description
+  }
+
+  return dict
 }
 
 /**
@@ -52,13 +77,14 @@ export function parseProfiles(stdout: string): ProfilesMap {
  * @throws Error if the ruyi command fails
  */
 export async function getProfilesFromRuyi(): Promise<ProfilesMap> {
-  const result = await ruyi.listProfiles()
-
-  if (result.code === 0) {
-    return parseProfiles(result.stdout)
+  try {
+    const result = await ruyi.listProfiles()
+    const profiles = parseProfilesOutput(result)
+    return parseProfiles(profiles)
   }
-  else {
-    logger.error(`Failed to get profiles: ${result.stderr}`)
-    throw new Error(`Failed to get profiles: ${result.stderr}`)
+  catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error)
+    logger.error(`Failed to get profiles: ${errorMsg}`)
+    throw new Error(`Failed to get profiles: ${errorMsg}`)
   }
 }

--- a/src/venv/types.ts
+++ b/src/venv/types.ts
@@ -49,9 +49,27 @@ export interface EmulatorInfo {
 }
 
 /**
- * Represents a Ruyi profile.
+ * Represents a Ruyi profile with structured data from ruyi CLI.
  */
-export type ProfilesMap = Record<string, string>
+export interface RuyiProfile {
+  /** Profile ID (e.g., "generic", "sipeed-lpi4a") */
+  id: string
+  /** Display name for UI */
+  displayName: string
+  /** Architecture (e.g., "riscv32", "riscv64") */
+  arch: string
+  /** Toolchain quirks required by this profile */
+  neededToolchainQuirks: string[]
+  /** Common toolchain flags for this profile */
+  toolchainCommonFlagsStr: string
+}
+
+/**
+ * Map of profile display names to their optional descriptions.
+ * Key is the profile display name for QuickPick label.
+ * Value is the description (e.g., quirks info) or undefined if none.
+ */
+export type ProfilesMap = Record<string, string | undefined>
 
 /**
  * Result type for emulator fetching that can be either success or error.


### PR DESCRIPTION
Declaration of the usage of `RUYI_EXPERIMENTAL` flag: 

It is reported that experimental features in Ruyi CLI could be seen as stable for downstream developers.

The command `RUYI_EXPERIMENTAL=1 ruyi --porcelain entity list -t profile-v1` prints multiple lines, one JSON per line. This kind of structured data is more reliable than using regex to match human-friendly output of `ruyi list profiles`.

## Summary by Sourcery

Refactor virtual environment profile handling to consume structured profile data from the Ruyi entity system and ensure experimental features are consistently enabled when invoking the Ruyi CLI.

Bug Fixes:
- Ensure profile descriptions in the venv creation UI are derived from structured quirks data rather than parsed human-readable output.

Enhancements:
- Replace regex-based parsing of `ruyi list profiles` output with JSON Lines parsing of `entity list -t profile-v1` results to build structured profile objects.
- Extend the venv types to model Ruyi profiles explicitly, including architecture, quirks, and common toolchain flags.
- Adjust venv profile selection to use precomputed profile descriptions instead of comparing raw labels.