### PR TITLE
feat(build): implement build system detection and execution module

### DIFF
--- a/media/build-rules.json
+++ b/media/build-rules.json
@@ -1,0 +1,56 @@
+{
+  "version": "1",
+  "description": "Build system detection rules for RuyiSDK VS Code Extension.\n\nPriority order (highest wins):\n  10 — CMake       : detected by CMakeLists.txt\n   5 — GNU Make    : detected by Makefile / GNUmakefile / makefile\n   1 — GCC (C)     : detected by any *.c file in the workspace root\n\nTo override, place a '.ruyi-build-rules.json' file in your workspace root\nusing the same schema. The workspace file replaces the bundled rules entirely,\nso copy any rules you still need.",
+  "rules": [
+    {
+      "id": "cmake",
+      "name": "CMake",
+      "priority": 10,
+      "indicators": ["CMakeLists.txt"],
+      "steps": [
+        {
+          "name": "Configure",
+          "command": "cmake",
+          "args": ["-B", "build", "-S", "."],
+          "workdir": "."
+        },
+        {
+          "name": "Build",
+          "command": "cmake",
+          "args": ["--build", "build"],
+          "workdir": "."
+        }
+      ]
+    },
+    {
+      "id": "gnu-make",
+      "name": "GNU Make",
+      "priority": 5,
+      "indicators": ["Makefile", "GNUmakefile", "makefile"],
+      "steps": [
+        {
+          "name": "Build",
+          "command": "make",
+          "args": [],
+          "workdir": "."
+        }
+      ]
+    },
+    {
+      "id": "c-gcc",
+      "name": "GCC (C)",
+      "priority": 1,
+      "indicators": [],
+      "indicatorGlobs": ["*.c"],
+      "steps": [
+        {
+          "name": "Compile",
+          "command": "for f in *.c; do gcc \"$f\" -o \"${f%.c}\"; done",
+          "args": [],
+          "workdir": ".",
+          "useShell": true
+        }
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -245,6 +245,12 @@
         "command": "ruyi.telemetry.configure",
         "title": "Configure Telemetry Settings",
         "category": "Ruyi"
+      },
+      {
+        "command": "ruyi.build.run",
+        "title": "Build Project",
+        "category": "Ruyi",
+        "icon": "$(play)"
       }
     ],
     "menus": {
@@ -300,6 +306,12 @@
           "command": "ruyi.venv.clean",
           "when": "view == ruyiVenvsView && viewItem == ruyiVenv.itemNonCurrent",
           "group": "inline@2"
+        }
+      ],
+      "editor/title": [
+        {
+          "command": "ruyi.build.run",
+          "group": "navigation@0"
         }
       ],
       "commandPalette": [

--- a/src/build/build-statusbar.provider.ts
+++ b/src/build/build-statusbar.provider.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * RuyiSDK VS Code Extension - Build Module - Status Bar Provider
+ *
+ * Provides a persistent "Build" button in the status bar.
+ * The button tooltip reflects the currently active Ruyi venv (if any) so the
+ * user always knows which environment will be used for the build.
+ *
+ * The context key `ruyi.venv.isActive` is also maintained here so that
+ * package.json `when` clauses (e.g. view/title build button) can respond to
+ * venv state changes.
+ */
+
+import * as path from 'path'
+import * as vscode from 'vscode'
+
+import { VenvService } from '../venv/venv.service'
+
+export class BuildStatusBarProvider implements vscode.Disposable {
+  private static _instance: BuildStatusBarProvider
+
+  private readonly item: vscode.StatusBarItem
+  private readonly disposables: vscode.Disposable[] = []
+
+  private constructor(private readonly venvService: VenvService) {
+    // Priority 99: renders just to the right of the venv status bar item (100)
+    this.item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 99)
+    this.item.command = 'ruyi.build.run'
+    this.disposables.push(this.item)
+
+    this.disposables.push(
+      venvService.onDidChangeVenv(() => this.update()),
+    )
+
+    this.update()
+    this.item.show()
+  }
+
+  public static getInstance(venvService: VenvService): BuildStatusBarProvider {
+    if (!BuildStatusBarProvider._instance) {
+      BuildStatusBarProvider._instance = new BuildStatusBarProvider(venvService)
+    }
+    return BuildStatusBarProvider._instance
+  }
+
+  private update(): void {
+    const venvPath = this.venvService.getCurrentVenv()
+
+    this.item.text = '$(play) Build'
+
+    if (venvPath) {
+      const venvName = path.basename(path.normalize(venvPath))
+      this.item.tooltip = new vscode.MarkdownString(
+        `**RuyiSDK Build**\n\nClick to build the project.\n\n`
+        + `Venv: \`${venvName}\` — build tools from the virtual environment will be used.`,
+      )
+    }
+    else {
+      this.item.tooltip = new vscode.MarkdownString(
+        `**RuyiSDK Build**\n\nClick to build the project.\n\n`
+        + `_No active venv — system build tools will be used._`,
+      )
+    }
+
+    // Keep the VS Code context key in sync so package.json when-clauses work
+    vscode.commands.executeCommand('setContext', 'ruyi.venv.isActive', venvPath !== null)
+  }
+
+  dispose(): void {
+    this.disposables.forEach(d => d.dispose())
+  }
+}

--- a/src/build/build.command.ts
+++ b/src/build/build.command.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * RuyiSDK VS Code Extension - Build Module - Command
+ *
+ * Registers the `ruyi.build.run` command which triggers build-system detection
+ * and executes all configured build steps.
+ */
+
+import * as vscode from 'vscode'
+
+import { BuildService } from './build.service'
+
+export default function registerBuildCommand(ctx: vscode.ExtensionContext): void {
+  ctx.subscriptions.push(
+    vscode.commands.registerCommand('ruyi.build.run', async () => {
+      await BuildService.instance.build(ctx.extensionUri)
+    }),
+  )
+}

--- a/src/build/build.service.ts
+++ b/src/build/build.service.ts
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * RuyiSDK VS Code Extension - Build Module - Service
+ *
+ * Responsibilities:
+ * - Load build system detection rules from a JSON rule file.
+ *   Rule precedence: workspace `.ruyi-build-rules.json` > bundled `media/build-rules.json`.
+ * - Detect the active build system by scanning workspace root for indicator files.
+ * - Execute build steps, optionally inside an active Ruyi virtual environment.
+ *
+ * When a Ruyi venv is active the step is run as:
+ *   bash -c 'source "$RUYI_ACTIVATE_SCRIPT" && exec "$@"' -- <command> [args…]
+ * The activation script path is passed through the RUYI_ACTIVATE_SCRIPT env var to
+ * avoid shell-quoting problems with paths that contain spaces or special characters.
+ * This guarantees that every compiler/tool variable set by ruyi-activate (CC, CXX,
+ * PATH, …) is present in the child process environment.
+ */
+
+import { spawn } from 'child_process'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as vscode from 'vscode'
+
+import { getWorkspaceFolderPath } from '../common/helpers'
+import { logger } from '../common/logger'
+import { VenvService } from '../venv/venv.service'
+
+// ─── Rule file schema ─────────────────────────────────────────────────────────
+
+/** A single build action (e.g. "configure" or "build"). */
+export interface BuildStep {
+  /** Human-readable label shown in progress messages. */
+  name: string
+  /** Executable name resolved via PATH (or venv bin directory). */
+  command: string
+  /** Arguments passed verbatim to the executable. */
+  args: string[]
+  /**
+   * Working directory relative to the workspace root.
+   * Defaults to "." (workspace root) when omitted.
+   */
+  workdir?: string
+  /**
+   * When true the step is executed via `bash -c` so the shell can expand
+   * globs (e.g. `*.c`), handle pipes, etc.  When combined with a Ruyi venv
+   * the activation script is sourced first.
+   *
+   * ⚠ Shell-unsafe for argument values that contain spaces — quote them
+   * explicitly in the rule file when needed.
+   */
+  useShell?: boolean
+}
+
+/** Describes one build system and how to detect and drive it. */
+export interface BuildRule {
+  /** Stable identifier used for logging and future extensions. */
+  id: string
+  /** Display name shown to the user (e.g. "CMake", "GNU Make"). */
+  name: string
+  /**
+   * Detection priority.  When multiple rules match the workspace, the rule
+   * with the highest priority wins (CMake > GNU Make by default).
+   */
+  priority: number
+  /**
+   * Exact file or directory names searched in the workspace root.
+   * The first indicator that exists causes this rule to match.
+   */
+  indicators: string[]
+  /**
+   * Glob patterns (relative to workspace root) used when exact `indicators`
+   * are insufficient.  Evaluated with `vscode.workspace.findFiles` after all
+   * `indicators` have been checked.  The rule matches when at least one file
+   * satisfies any of the patterns.
+   *
+   * Example: `["*.c"]` matches any C source file in the workspace root.
+   */
+  indicatorGlobs?: string[]
+  /** Ordered list of steps to execute when building. */
+  steps: BuildStep[]
+}
+
+/** Top-level structure of a build-rules JSON file. */
+export interface BuildRulesConfig {
+  version: string
+  description?: string
+  rules: BuildRule[]
+}
+
+/** Result returned by detectBuildSystem(). */
+export interface DetectedBuildSystem {
+  rule: BuildRule
+  workspaceRoot: string
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/**
+ * Filename for a workspace-level rule override.
+ * When present, replaces the bundled rule set entirely.
+ */
+const WORKSPACE_RULES_FILE = '.ruyi-build-rules.json'
+
+// ─── Service ──────────────────────────────────────────────────────────────────
+
+export class BuildService implements vscode.Disposable {
+  private static _instance: BuildService
+  private _outputChannel: vscode.OutputChannel | null = null
+
+  private constructor() {}
+
+  public static get instance(): BuildService {
+    if (!BuildService._instance) {
+      BuildService._instance = new BuildService()
+    }
+    return BuildService._instance
+  }
+
+  private get outputChannel(): vscode.OutputChannel {
+    if (!this._outputChannel) {
+      this._outputChannel = vscode.window.createOutputChannel('RuyiSDK Build')
+    }
+    return this._outputChannel
+  }
+
+  // ─── Rule loading ──────────────────────────────────────────────────────────
+
+  /**
+   * Loads build rules with workspace-level override support.
+   *
+   * Priority:
+   *   1. `<workspaceRoot>/.ruyi-build-rules.json`  (user-defined)
+   *   2. `media/build-rules.json` bundled with the extension
+   */
+  public async loadRules(extensionUri: vscode.Uri): Promise<BuildRulesConfig> {
+    // 1. Workspace override
+    try {
+      const workspaceRoot = getWorkspaceFolderPath()
+      const overridePath = path.join(workspaceRoot, WORKSPACE_RULES_FILE)
+      const raw = fs.readFileSync(overridePath, 'utf8')
+      logger.info(`Build rules loaded from workspace override: ${overridePath}`)
+      return JSON.parse(raw) as BuildRulesConfig
+    }
+    catch {
+      // No workspace override – fall through
+    }
+
+    // 2. Bundled rules
+    const bundledUri = vscode.Uri.joinPath(extensionUri, 'media', 'build-rules.json')
+    const bytes = await vscode.workspace.fs.readFile(bundledUri)
+    return JSON.parse(Buffer.from(bytes).toString('utf8')) as BuildRulesConfig
+  }
+
+  // ─── Build system detection ────────────────────────────────────────────────
+
+  /**
+   * Scans the workspace root for indicator files and returns the best-matching
+   * build rule, or `null` if the workspace has no open folder or no rule matches.
+   */
+  public async detectBuildSystem(extensionUri: vscode.Uri): Promise<DetectedBuildSystem | null> {
+    let workspaceRoot: string
+    try {
+      workspaceRoot = getWorkspaceFolderPath()
+    }
+    catch {
+      return null
+    }
+
+    const config = await this.loadRules(extensionUri)
+
+    // Evaluate rules from highest to lowest priority
+    const sorted = [...config.rules].sort((a, b) => b.priority - a.priority)
+
+    for (const rule of sorted) {
+      // 1. Exact filename indicators (fast, synchronous)
+      for (const indicator of rule.indicators) {
+        const candidate = path.join(workspaceRoot, indicator)
+        if (fs.existsSync(candidate)) {
+          logger.info(`Detected build system: ${rule.name} (matched indicator: ${indicator})`)
+          return { rule, workspaceRoot }
+        }
+      }
+
+      // 2. Glob indicators (async, used when no exact indicator matched)
+      if (rule.indicatorGlobs && rule.indicatorGlobs.length > 0) {
+        for (const glob of rule.indicatorGlobs) {
+          const pattern = new vscode.RelativePattern(workspaceRoot, glob)
+          const files = await vscode.workspace.findFiles(pattern, null, 1)
+          if (files.length > 0) {
+            logger.info(`Detected build system: ${rule.name} (matched glob: ${glob} → ${files[0].fsPath})`)
+            return { rule, workspaceRoot }
+          }
+        }
+      }
+    }
+
+    return null
+  }
+
+  // ─── Build execution ───────────────────────────────────────────────────────
+
+  /**
+   * Detects the build system in the workspace and runs all of its steps.
+   * When a Ruyi venv is active, each step is executed inside that environment.
+   */
+  public async build(extensionUri: vscode.Uri): Promise<void> {
+    const detected = await this.detectBuildSystem(extensionUri)
+    if (!detected) {
+      vscode.window.showWarningMessage(
+        'No supported build system found in the workspace. '
+        + 'Supported: CMake (CMakeLists.txt), GNU Make (Makefile), GCC (*.c). '
+        + 'You can also add a .ruyi-build-rules.json to the workspace root to define custom rules.',
+      )
+      return
+    }
+
+    const { rule, workspaceRoot } = detected
+    const venvPath = VenvService.instance.getCurrentVenv()
+
+    this.outputChannel.clear()
+    this.outputChannel.show(true)
+    this.outputChannel.appendLine(`=== RuyiSDK Build: ${rule.name} ===`)
+    if (venvPath) {
+      this.outputChannel.appendLine(`Virtual environment : ${venvPath}`)
+    }
+    else {
+      this.outputChannel.appendLine('Virtual environment : none (building without venv)')
+    }
+    this.outputChannel.appendLine('')
+
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: `Building with ${rule.name}`,
+        cancellable: false,
+      },
+      async (progress) => {
+        const total = rule.steps.length
+
+        for (let i = 0; i < total; i++) {
+          const step = rule.steps[i]
+
+          progress.report({
+            message: step.name,
+            increment: i === 0 ? 0 : Math.floor(100 / total),
+          })
+
+          this.outputChannel.appendLine(`--- ${step.name} ---`)
+
+          const stepWorkdir = step.workdir
+            ? path.resolve(workspaceRoot, step.workdir)
+            : workspaceRoot
+
+          let exitCode: number
+          try {
+            exitCode = await this.runStep(step, stepWorkdir, venvPath)
+          }
+          catch (err) {
+            this.outputChannel.appendLine(`\n✗ Step '${step.name}' could not start: ${err}`)
+            vscode.window.showErrorMessage(
+              `Build failed: could not start '${step.command}'. `
+              + 'Is it installed and on PATH?',
+            )
+            return
+          }
+
+          if (exitCode !== 0) {
+            this.outputChannel.appendLine(
+              `\n✗ Step '${step.name}' failed (exit code ${exitCode})`,
+            )
+            vscode.window.showErrorMessage(
+              `Build failed at step '${step.name}' (exit code ${exitCode}). `
+              + 'See the "RuyiSDK Build" output panel for details.',
+            )
+            return
+          }
+
+          this.outputChannel.appendLine('')
+        }
+
+        progress.report({ increment: 100, message: 'Done' })
+        this.outputChannel.appendLine('=== Build succeeded ===')
+        vscode.window.showInformationMessage(`✓ Build succeeded (${rule.name})`)
+      },
+    )
+  }
+
+  // ─── Internal helpers ──────────────────────────────────────────────────────
+
+  /**
+   * Spawns a single build step and streams its output to the output channel.
+   *
+   * @param step      The build step to execute.
+   * @param workdir   Absolute working directory for the process.
+   * @param venvPath  Absolute path to the active Ruyi venv, or null.
+   * @returns         The process exit code (0 = success).
+   */
+  private runStep(
+    step: BuildStep,
+    workdir: string,
+    venvPath: string | null,
+  ): Promise<number> {
+    return new Promise((resolve, reject) => {
+      let spawnCmd: string
+      let spawnArgs: string[]
+      const spawnEnv: NodeJS.ProcessEnv = { ...process.env }
+
+      const activateScript = venvPath ? path.join(venvPath, 'bin', 'ruyi-activate') : ''
+
+      if (step.useShell) {
+        /**
+         * Shell mode: join command + args into a single shell string so the
+         * shell can expand globs, pipes, etc.
+         * If a venv is active, the activation script is sourced first.
+         */
+        const shellCmd = [step.command, ...step.args].join(' ')
+        spawnCmd = 'bash'
+        if (venvPath) {
+          spawnArgs = ['-c', 'source "$RUYI_ACTIVATE_SCRIPT" && ' + shellCmd]
+          spawnEnv.RUYI_ACTIVATE_SCRIPT = activateScript
+        }
+        else {
+          spawnArgs = ['-c', shellCmd]
+        }
+      }
+      else if (venvPath) {
+        /**
+         * Safe mode with venv: pass command + args as positional parameters so
+         * they are never re-parsed by the shell.
+         *
+         * bash -c 'source "$RUYI_ACTIVATE_SCRIPT" && exec "$@"' -- cmd [args…]
+         *   $0 = "--"  (placeholder)
+         *   $@ = cmd args…  (exec'd verbatim, no word-splitting)
+         */
+        spawnCmd = 'bash'
+        spawnArgs = [
+          '-c',
+          'source "$RUYI_ACTIVATE_SCRIPT" && exec "$@"',
+          '--',
+          step.command,
+          ...step.args,
+        ]
+        spawnEnv.RUYI_ACTIVATE_SCRIPT = activateScript
+      }
+      else {
+        // Safe mode, no venv: spawn directly, no shell involved
+        spawnCmd = step.command
+        spawnArgs = step.args
+      }
+
+      const proc = spawn(spawnCmd, spawnArgs, {
+        cwd: workdir,
+        env: spawnEnv,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+
+      proc.stdout.on('data', (chunk: Buffer) => {
+        this.outputChannel.append(chunk.toString())
+      })
+
+      proc.stderr.on('data', (chunk: Buffer) => {
+        this.outputChannel.append(chunk.toString())
+      })
+
+      proc.on('close', (code) => {
+        resolve(code ?? -1)
+      })
+
+      proc.on('error', reject)
+    })
+  }
+
+  dispose(): void {
+    this._outputChannel?.dispose()
+  }
+}

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * RuyiSDK VS Code Extension - Build Module
+ *
+ * Barrel / registration file.
+ *
+ * Exported symbols:
+ *  - registerBuildModule  (default export used by extension.ts)
+ *  - BuildService
+ *  - BuildStatusBarProvider
+ *  - Rule schema types
+ */
+
+import * as vscode from 'vscode'
+
+import { VenvService } from '../venv/venv.service'
+
+import { BuildStatusBarProvider } from './build-statusbar.provider'
+import registerBuildCommand from './build.command'
+import { BuildService } from './build.service'
+
+export default function registerBuildModule(ctx: vscode.ExtensionContext): void {
+  // Use singleton venv service so status bar state tracks active venv changes
+  const venvService = VenvService.instance
+
+  // Initialize build status bar provider (singleton)
+  const statusBarProvider = BuildStatusBarProvider.getInstance(venvService)
+
+  // Register the build command
+  registerBuildCommand(ctx)
+
+  // Register UI provider so it is disposed with the extension context
+  ctx.subscriptions.push(statusBarProvider)
+
+  // Register the build service itself so its output channel is cleaned up
+  ctx.subscriptions.push(BuildService.instance)
+}
+
+export { BuildStatusBarProvider } from './build-statusbar.provider'
+export { BuildService } from './build.service'
+export type { BuildRule, BuildRulesConfig, BuildStep, DetectedBuildSystem } from './build.service'

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,7 @@
 
 import * as vscode from 'vscode'
 
+import registerBuildModule from './build'
 import { configuration } from './common/configuration'
 import { logger } from './common/logger'
 import registerHomeModule from './home'
@@ -45,6 +46,7 @@ export function activate(context: vscode.ExtensionContext) {
   registerSetupModule(context)
   registerNewsModule(context)
   registerVenvModule(context)
+  registerBuildModule(context)
 
   // Initialize logger
   logger.initialize('RuyiSDK')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,9 @@
 		"lib": [
 			"ES2022"
 		],
+		"types": [
+			"node"
+		],
 		"sourceMap": true,
 		"rootDir": "src",
 		"strict": true,   /* enable all strict type-checking options */


### PR DESCRIPTION
This pull request introduces a comprehensive build system integration into the RuyiSDK VS Code Extension. It adds support for automatic build system detection (CMake, GNU Make, GCC), a unified "Build Project" command, and a status bar button. The implementation is modular, supports workspace-level rule overrides, and ensures builds run in the correct environment (system or Ruyi venv).

**Build System Integration**

* Added a build system detection and execution service (`BuildService`) that loads rules from `media/build-rules.json` or a workspace override, detects the active build system, and executes build steps, optionally inside a Ruyi virtual environment.
* Introduced a build rules schema and default rules for CMake, GNU Make, and GCC in `media/build-rules.json`. Users can override or extend these rules per workspace.

**User Interface Enhancements**

* Registered a new command `ruyi.build.run` ("Build Project") with a play icon, available in the command palette and editor title bar. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R248-R253) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R311-R316)
* Added a status bar provider (`BuildStatusBarProvider`) that shows a persistent "Build" button reflecting the current venv state.

**Extension Integration and Module Organization**

* Registered the build module in the extension activation process, ensuring all build features are initialized and cleaned up properly. [[1]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R30) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R49)
* Added a barrel file for the build module, exporting all relevant symbols and types for use throughout the extension.
---
# Build Rules Reference

The RuyiSDK extension ships a built-in set of build-system detection rules.
You can override them for a specific workspace by placing a
`.ruyi-build-rules.json` file in the workspace root.

---

## Rule resolution

When the **Build** button is clicked, the extension resolves which rule set to
use as follows:

1. If `<workspaceRoot>/.ruyi-build-rules.json` exists, load it.
   **This file replaces the bundled rules entirely.**
   > A workspace rule file is always used as a complete, standalone rule set — it is never merged with the bundled rules, so `priority` only matters when the file itself contains more than one rule.
2. Otherwise, fall back to the rules bundled with the extension
   (`media/build-rules.json`).

After loading the rule set, each rule is evaluated from highest `priority` to
lowest.  The first rule whose `indicators` or `indicatorGlobs` match a file in
the workspace root wins.

---

## Toolchain selection

| Condition | Toolchain used |
|---|---|
| A Ruyi virtual environment is active | The venv's toolchain (`CC`, `CXX`, `PATH`, … set by `ruyi-activate`) |
| No virtual environment is active | The system toolchain on `$PATH` |

Toolchain selection is automatic and requires no configuration in the rule
file.

---
## Schema summary

```
BuildRulesConfig
├── version        string          (required)
├── description    string          (optional)
└── rules          Rule[]          (required)
     ├── id              string    (required)
     ├── name            string    (required)
     ├── priority        number    (required)
     ├── indicators      string[]  (required)
     ├── indicatorGlobs  string[]  (optional)
     └── steps           Step[]    (required)
          ├── name        string   (required)
          ├── command     string   (required)
          ├── args        string[] (required)
          ├── workdir     string   (optional, default ".")
          └── useShell    boolean  (optional, default false)
```


---

## Top-level fields

```jsonc
{
  "version": "1",          // required
  "description": "...",    // optional, human-readable
  "rules": [ … ]           // required, array of Rule objects
}
```

| Field | Type | Required | Description |
|---|---|---|---|
| `version` | `string` | Yes | Schema version. Must be `"1"`. |
| `description` | `string` | No | Free-form human-readable text. Ignored by the extension. |
| `rules` | `Rule[]` | Yes | Ordered list of build rules. See [Rule object](#rule-object). |

---

## Rule object

```jsonc
{
  "id":              "gnu-make",
  "name":            "GNU Make",
  "priority":        5,
  "indicators":      ["Makefile", "GNUmakefile", "makefile"],
  "indicatorGlobs":  [],
  "steps":           [ … ]
}
```

| Field | Type | Required | Description |
|---|---|---|---|
| `id` | `string` | Yes | Stable, unique identifier for this rule. Used in logs and for future extensions. Use lowercase ASCII and hyphens (e.g. `cmake`, `gnu-make`). |
| `name` | `string` | Yes | Human-readable display name shown in progress notifications and the build output panel. |
| `priority` | `number` | Yes | Detection priority. When multiple rules match the workspace, the one with the **highest** value wins. Negative values are allowed. |
| `indicators` | `string[]` | Yes | List of exact file or directory names to look for in the **workspace root**. The rule matches as soon as **any one** of them exists. Pass an empty array `[]` if you rely solely on `indicatorGlobs`. |
| `indicatorGlobs` | `string[]` | No | List of [glob patterns](https://code.visualstudio.com/api/references/vscode-api#RelativePattern) evaluated relative to the workspace root. The rule matches when **any one** pattern produces at least one result. Evaluated only when no `indicators` entry matched. Omit the field or pass `[]` to disable glob detection. |
| `steps` | `Step[]` | Yes | Ordered list of build steps. Steps are executed sequentially; the build stops on the first non-zero exit code. See [Step object](#step-object). |

### Priority guidelines (built-in defaults)

| Priority | Build system | Detection trigger |
|---|---|---|
| 10 | CMake | `CMakeLists.txt` exists in workspace root |
| 5 | GNU Make | `Makefile`, `GNUmakefile`, or `makefile` exists in workspace root |
| 1 | GCC (C) | Any `*.c` file exists in workspace root |



---

## Step object

```jsonc
{
  "name":     "Build",
  "command":  "make",
  "args":     ["compile", "PORT_DIR=linux64"],
  "workdir":  ".",
  "useShell": false
}
```

| Field | Type | Required | Default | Description |
|---|---|---|---|---|
| `name` | `string` | Yes | — | Label shown in the progress notification and the **RuyiSDK Build** output panel. |
| `command` | `string` | Yes | — | The executable to run, or — when `useShell` is `true` — the complete shell command string (including pipes, loops, expansions, etc.). |
| `args` | `string[]` | Yes | — | Arguments appended to `command`. Ignored by the shell when `useShell` is `true` (put everything in `command` instead). |
| `workdir` | `string` | No | `"."` | Working directory relative to the workspace root. The path is resolved against the workspace root with `path.resolve()`. |
| `useShell` | `boolean` | No | `false` | When `true`, the step is executed as `bash -c '<command>'` instead of being spawned directly. This enables shell features such as glob expansion, `for` loops, pipelines, and variable substitution. See [Shell mode](#shell-mode). |

### Shell mode

`useShell: true` is needed when:

- the command contains shell syntax (`*.c`, `for f in …`, `|`, `&&`, `$VAR`)
- argument values themselves must be expanded by the shell

**When a Ruyi venv is active**, the activation script is sourced before the
command runs:

```bash
# Effective command when venv is active and useShell is true
bash -c 'source "$RUYI_ACTIVATE_SCRIPT" && <your command>'
```

**When no venv is active**:

```bash
bash -c '<your command>'
```

> **Warning — avoid `useShell` for file-mutating commands that are not
> idempotent.**
> Commands such as `sed -i` permanently modify files.  Repeating them on each
> build may produce cumulative, unintended edits (e.g. a compiler prefix being
> prepended multiple times).  Prefer passing variables to `make` instead:
>
> ```jsonc
> // preferred — idempotent
> { "command": "make", "args": ["CC=riscv64-linux-gnu-gcc", "compile"] }
>
> // avoid for repeated builds
> { "command": "sed -i 's/gcc/riscv64-linux-gnu-gcc/' Makefile", "useShell": true }
> ```

---

## Complete example

The following workspace-level `.ruyi-build-rules.json` builds
[CoreMark](https://github.com/eembc/coremark) for a 64-bit RISC-V target using
the `linux64` port, compiling only (no run):

```json
{
  "version": "1",
  "rules": [
    {
      "id": "gnu-make-coremark",
      "name": "GNU Make (CoreMark linux64)",
      "priority": 20,
      "indicators": ["Makefile"],
      "steps": [
        {
          "name": "Build",
          "command": "make",
          "args": ["compile", "PORT_DIR=linux64"],
          "workdir": "."
        }
      ]
    }
  ]
}
```

- When a Ruyi venv is active, `CC` and related variables are supplied
  automatically by the virtual environment.
- When no venv is active, the system `make` and `gcc` are used.
- The `compile` target builds the binary without attempting to run it, which
  avoids a segmentation fault when cross-compiling for a target architecture.

## Summary by Sourcery

Introduce a build module that detects and runs workspace build systems from configurable rules and exposes a unified build entry point in the extension.

New Features:
- Add a BuildService that loads build rules, detects the active build system, and executes configured build steps with optional Ruyi virtual environment integration.
- Provide a persistent status bar Build button and a `ruyi.build.run` command available from the command palette and editor title bar to trigger project builds.
- Ship a default build-rules configuration file supporting common build systems that can be overridden per workspace via a `.ruyi-build-rules.json` file.

Enhancements:
- Register the build module in the extension activation lifecycle and expose its types via a barrel file for reuse.
- Update TypeScript configuration to include Node.js type definitions for compatibility with new build logic.