### PR TITLE
fix(setup): avoid false update prompt when multiple ruyi versions are installed

### DIFF
--- a/src/setup/manage.command.ts
+++ b/src/setup/manage.command.ts
@@ -79,7 +79,7 @@ export function registerManageCommand(ctx: vscode.ExtensionContext): void {
           location: vscode.ProgressLocation.Notification,
           title: 'Detecting RuyiSDK installations...',
         },
-        listAllInstallations,
+        () => listAllInstallations(),
       )
 
       if (installations.length === 0) {

--- a/src/setup/manage.service.ts
+++ b/src/setup/manage.service.ts
@@ -42,6 +42,10 @@ export interface RuyiInstallation {
   tags?: string[]
 }
 
+interface ListInstallationsOptions {
+  includeTags?: boolean
+}
+
 /**
  * Fetch all releases from GitHub
  */
@@ -153,11 +157,13 @@ export async function getRuyiVersion(ruyiPath: string): Promise<string | undefin
  * List all RuyiSDK installations with version information
  * Installations are sorted by version (newest first)
  */
-export async function listAllInstallations(): Promise<RuyiInstallation[]> {
+export async function listAllInstallations(options: ListInstallationsOptions = {}): Promise<RuyiInstallation[]> {
   logger.info('Scanning for RuyiSDK installations...')
 
+  const includeTags = options.includeTags ?? true
+
   // Fetch GitHub releases for version tagging
-  const githubReleases = await fetchGitHubReleases()
+  const githubReleases = includeTags ? await fetchGitHubReleases() : []
 
   // Find all Ruyi executables
   const candidates: string[] = []

--- a/src/setup/setup.command.ts
+++ b/src/setup/setup.command.ts
@@ -6,7 +6,7 @@ import * as semver from 'semver'
 
 import { logger } from '../common/logger'
 
-import { detectRuyiInstallation, fetchGitHubReleases } from './manage.service'
+import { detectRuyiInstallation, fetchGitHubReleases, listAllInstallations } from './manage.service'
 import {
   executeRuyiInstall,
   executeRuyiUpdate,
@@ -75,8 +75,8 @@ async function handleSuccessAndPromptReload(
 
 export async function checkRuyiUpdate(currentVersion: string): Promise<void> {
   try {
-    const coerced = semver.coerce(currentVersion)
-    if (!coerced) {
+    const currentCoerced = semver.coerce(currentVersion)
+    if (!currentCoerced) {
       logger.warn(`Unable to parse version from: ${currentVersion}`)
       return
     }
@@ -94,12 +94,23 @@ export async function checkRuyiUpdate(currentVersion: string): Promise<void> {
     }
 
     const latestVersion = latestRelease.tag_name.replace(/^v/, '')
-    if (!semver.gt(latestVersion, coerced.version)) {
+    const latestStableCoerced = semver.coerce(latestVersion)
+    if (!latestStableCoerced) {
+      logger.warn(`Unable to parse latest stable version from GitHub tag: ${latestRelease.tag_name}`)
+      return
+    }
+
+    const installations = await listAllInstallations({ includeTags: false })
+    const latestInstalledVersion = installations.find(item => item.parsedVersion)?.parsedVersion
+      ?? currentCoerced
+
+    // Only prompt when the latest installed local version is behind GitHub latest stable.
+    if (!semver.gt(latestStableCoerced, latestInstalledVersion)) {
       return
     }
 
     const choice = await vscode.window.showInformationMessage(
-      `A new version of Ruyi is available: ${latestVersion} (current: ${coerced.version})`,
+      `A new version of Ruyi is available: ${latestVersion} (current: ${currentCoerced.version})`,
       'Update now',
       'Later',
     )


### PR DESCRIPTION
Fix issue #115 
This pull request introduces improvements to the RuyiSDK installation management and update-checking logic, primarily by refining how installations are listed and how version comparisons are handled. The changes make the code more robust and flexible, especially when determining whether to prompt users for updates.

**Improvements to installation listing and version management:**

- Added a `ListInstallationsOptions` interface and updated `listAllInstallations` to accept options, allowing callers to control whether GitHub release tags are fetched [[1]](diffhunk://#diff-9be99e0acdf4b17d9469dd03937371ab348dae98d318ac92e9332d186784e922R45-R48) [[2]](diffhunk://#diff-9be99e0acdf4b17d9469dd03937371ab348dae98d318ac92e9332d186784e922L156-R166).
- Changed the update check logic in `checkRuyiUpdate` to compare the latest installed local version (ignoring tags) with the latest stable GitHub release, ensuring users are only prompted when their installed version is actually outdated.

**Code quality and clarity enhancements:**

- Improved variable naming in version parsing for clarity (e.g., `coerced` → `currentCoerced`, `latestStableCoerced`).
- Updated the usage of `listAllInstallations` in the command registration to use the new function signature.
- Added the missing import for `listAllInstallations` in `setup.command.ts`.

## Summary by Sourcery

Refine RuyiSDK update-checking to avoid false update prompts when multiple versions are installed by considering the latest locally installed version against the latest stable GitHub release.

Bug Fixes:
- Ensure update prompts are only shown when the newest locally installed RuyiSDK version is older than the latest stable GitHub release.

Enhancements:
- Add optional parameters to the installation listing API to control whether GitHub release tags are fetched.
- Adjust callers and variable naming to align with the new installation listing options and improve version parsing clarity.