### PR TITLE
feat(home): add walkthrough and forum options to home panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,6 +159,11 @@
         "category": "Ruyi"
       },
       {
+        "command": "ruyi.home.show",
+        "title": "Show Home Page",
+        "category": "Ruyi"
+      },
+      {
         "command": "ruyi.news.search",
         "title": "Search News",
         "category": "Ruyi",

--- a/src/home/home-webview.provider.ts
+++ b/src/home/home-webview.provider.ts
@@ -2,8 +2,11 @@
 import * as vscode from 'vscode'
 
 let panel: vscode.WebviewPanel | undefined
+let extensionId = ''
 
 export function showHomePanel(ctx: vscode.ExtensionContext) {
+  extensionId = ctx.extension.id
+
   if (panel) {
     panel.reveal(vscode.ViewColumn.One)
     return
@@ -21,11 +24,17 @@ export function showHomePanel(ctx: vscode.ExtensionContext) {
 }
 
 async function handleMessage(msg: { type: string }) {
-  if (msg.type === 'openNews') {
+  if (msg.type === 'openWalkthrough') {
+    await vscode.commands.executeCommand('workbench.action.openWalkthrough', `${extensionId}#ruyi.welcome`, false)
+  }
+  else if (msg.type === 'openNews') {
     await vscode.commands.executeCommand('ruyi.news.showCards')
   }
   else if (msg.type === 'openPackages') {
     await vscode.commands.executeCommand('ruyiPackagesView.focus')
+  }
+  else if (msg.type === 'openForum') {
+    await vscode.env.openExternal(vscode.Uri.parse('https://ruyisdk.cn'))
   }
 }
 
@@ -58,7 +67,7 @@ function getHtml(): string {
     .subtitle { margin: 8px 0 0; font-size: 18px; color: var(--vscode-descriptionForeground); }
     .cards { display: flex; gap: 24px; flex-wrap: wrap; max-width: 960px; }
     .card {
-      flex: 1 1 320px;
+      flex: 1 1 220px;
       min-height: 200px;
       padding: 32px;
       border-radius: 12px;
@@ -98,6 +107,13 @@ function getHtml(): string {
   <section class="cards">
     <article class="card">
       <div>
+        <h2>Walkthrough</h2>
+        <p>Open the getting started walkthrough and follow the guided setup flow</p>
+      </div>
+      <button onclick="vscode.postMessage({type:'openWalkthrough'})">Open Walkthrough</button>
+    </article>
+    <article class="card">
+      <div>
         <h2>News</h2>
         <p>View the latest RuyiSDK release notes and announcements</p>
       </div>
@@ -105,10 +121,17 @@ function getHtml(): string {
     </article>
     <article class="card">
       <div>
-        <h2>Packages</h2>
+        <h2>Package</h2>
         <p>Browse, install, and manage software packages</p>
       </div>
-      <button onclick="vscode.postMessage({type:'openPackages'})">Browse Packages</button>
+      <button onclick="vscode.postMessage({type:'openPackages'})">Browse Package</button>
+    </article>
+    <article class="card">
+      <div>
+        <h2>Forum</h2>
+        <p>Visit the Ruyi community forum and discover more resources</p>
+      </div>
+      <button onclick="vscode.postMessage({type:'openForum'})">Go to Forum</button>
     </article>
   </section>
   <script>const vscode = acquireVsCodeApi();</script>


### PR DESCRIPTION
This pull request enhances the RuyiSDK extension's home page by adding new navigation options and improving the user interface for better accessibility and onboarding. The most significant changes include introducing a walkthrough and forum access from the home page, updating command registration, and refining UI elements.

**Home page functionality and UI enhancements:**

* Added a new "Walkthrough" card to the home webview, allowing users to launch a guided getting started flow directly from the home page. [[1]](diffhunk://#diff-857980a441369f9f59445f9dac8a738302d56ec3176b4c1fc0f0d0c5fc8f1da7R108-R114) [[2]](diffhunk://#diff-857980a441369f9f59445f9dac8a738302d56ec3176b4c1fc0f0d0c5fc8f1da7L24-R38)
* Added a "Forum" card and button to the home webview, providing quick access to the Ruyi community forum. [[1]](diffhunk://#diff-857980a441369f9f59445f9dac8a738302d56ec3176b4c1fc0f0d0c5fc8f1da7L108-R134) [[2]](diffhunk://#diff-857980a441369f9f59445f9dac8a738302d56ec3176b4c1fc0f0d0c5fc8f1da7L24-R38)
* Adjusted the card layout in the home webview for improved appearance and usability (reduced minimum width for cards).

**Command and message handling improvements:**

* Registered a new `ruyi.home.show` command in `package.json` to support showing the home page via command palette.
* Improved message handling in the home webview provider to support the new "openWalkthrough" and "openForum" actions, including dynamic extension ID resolution for walkthroughs. [[1]](diffhunk://#diff-857980a441369f9f59445f9dac8a738302d56ec3176b4c1fc0f0d0c5fc8f1da7R5-R9) [[2]](diffhunk://#diff-857980a441369f9f59445f9dac8a738302d56ec3176b4c1fc0f0d0c5fc8f1da7L24-R38)

## Summary by Sourcery

Enhance the RuyiSDK home webview with new onboarding and community entry points and expose it via a dedicated command.

New Features:
- Add a Walkthrough card on the home panel that opens the extension's getting started walkthrough.
- Add a Forum card on the home panel that links to the Ruyi community site.
- Register a `ruyi.home.show` command to display the home page from the command palette.

Enhancements:
- Adjust home panel card layout to support narrower cards and improve responsiveness.