### PR TITLE
fix(build): enhance build system detection with venv-aware strategies and logging

### DIFF
--- a/media/build-rules.json
+++ b/media/build-rules.json
@@ -11,8 +11,30 @@
         {
           "name": "Configure",
           "command": "cmake",
-          "args": ["-B", "build", "-S", "."],
+          "args": ["-DCMAKE_TOOLCHAIN_FILE=./${RUYI_VENV_PROMPT}/toolchain.cmake", "-DCMAKE_INSTALL_PREFIX=./${RUYI_VENV_PROMPT}/sysroot.riscv64-unknown-linux-gnu", "-B", "build", "-S", "."],
+          "workdir": ".",
+          "useShell": true
+        },
+        {
+          "name": "Build",
+          "command": "cmake",
+          "args": ["--build", "build"],
           "workdir": "."
+        }
+      ]
+    },
+    {
+      "id": "cmake-local",
+      "name": "CMake",
+      "priority": 10,
+      "indicators": ["CMakeLists.txt"],
+      "steps": [
+        {
+          "name": "Configure",
+          "command": "cmake",
+          "args": ["-B", "build", "-S", "."],
+          "workdir": ".",
+          "useShell": true
         },
         {
           "name": "Build",
@@ -38,6 +60,21 @@
     },
     {
       "id": "c-gcc",
+      "name": "GCC (C)",
+      "priority": 1,
+      "indicators": [],
+      "indicatorGlobs": ["*.c"],
+      "steps": [
+        {
+          "name": "Compile",
+          "command": "for f in *.c; do ${RUYI_VENV_PROMPT}/bin/*-gcc \"$f\" -o \"${f%.c}\"; done",
+          "args": [],
+          "workdir": ".",
+          "useShell": true
+        }
+      ]
+    },{
+      "id": "c-gcc-local",
       "name": "GCC (C)",
       "priority": 1,
       "indicators": [],

--- a/src/build/build.service.ts
+++ b/src/build/build.service.ts
@@ -123,6 +123,46 @@ export class BuildService implements vscode.Disposable {
     return this._outputChannel
   }
 
+  /** Formats a build step command line for human-readable logging. */
+  private formatStepCommandForLog(step: BuildStep): string {
+    const quoteIfNeeded = (part: string): string => {
+      if (part.length === 0) {
+        return '""'
+      }
+      if (/\s|"/.test(part)) {
+        return `"${part.replace(/"/g, '\\"')}"`
+      }
+      return part
+    }
+
+    return [step.command, ...step.args].map(quoteIfNeeded).join(' ')
+  }
+
+  /**
+   * Selects venv-aware strategy variants when available.
+   * Active venv -> base rule (`cmake` / `c-gcc`), otherwise -> local rule.
+   * Falls back to the matched rule when the preferred variant is unavailable.
+   */
+  private pickVenvAwareRule(config: BuildRulesConfig, fallback: BuildRule): BuildRule {
+    const venvAwarePairs: Record<string, { active: string, local: string }> = {
+      'cmake': { active: 'cmake', local: 'cmake-local' },
+      'cmake-local': { active: 'cmake', local: 'cmake-local' },
+      'c-gcc': { active: 'c-gcc', local: 'c-gcc-local' },
+      'c-gcc-local': { active: 'c-gcc', local: 'c-gcc-local' },
+    }
+
+    const pair = venvAwarePairs[fallback.id]
+    if (!pair) {
+      return fallback
+    }
+
+    const hasActiveVenv = !!VenvService.instance.getCurrentVenv()
+    const preferredId = hasActiveVenv ? pair.active : pair.local
+    const preferred = config.rules.find(r => r.id === preferredId)
+
+    return preferred ?? fallback
+  }
+
   // ─── Rule loading ──────────────────────────────────────────────────────────
 
   /**
@@ -176,8 +216,9 @@ export class BuildService implements vscode.Disposable {
       for (const indicator of rule.indicators) {
         const candidate = path.join(workspaceRoot, indicator)
         if (fs.existsSync(candidate)) {
-          logger.info(`Detected build system: ${rule.name} (matched indicator: ${indicator})`)
-          return { rule, workspaceRoot }
+          const selectedRule = this.pickVenvAwareRule(config, rule)
+          logger.info(`Detected build system: ${selectedRule.name} (matched indicator: ${indicator}, rule id: ${selectedRule.id})`)
+          return { rule: selectedRule, workspaceRoot }
         }
       }
 
@@ -187,8 +228,9 @@ export class BuildService implements vscode.Disposable {
           const pattern = new vscode.RelativePattern(workspaceRoot, glob)
           const files = await vscode.workspace.findFiles(pattern, null, 1)
           if (files.length > 0) {
-            logger.info(`Detected build system: ${rule.name} (matched glob: ${glob} → ${files[0].fsPath})`)
-            return { rule, workspaceRoot }
+            const selectedRule = this.pickVenvAwareRule(config, rule)
+            logger.info(`Detected build system: ${selectedRule.name} (matched glob: ${glob} → ${files[0].fsPath}, rule id: ${selectedRule.id})`)
+            return { rule: selectedRule, workspaceRoot }
           }
         }
       }
@@ -250,6 +292,9 @@ export class BuildService implements vscode.Disposable {
           const stepWorkdir = step.workdir
             ? path.resolve(workspaceRoot, step.workdir)
             : workspaceRoot
+
+          this.outputChannel.appendLine(`Workdir : ${stepWorkdir}`)
+          this.outputChannel.appendLine(`Command : ${this.formatStepCommandForLog(step)}`)
 
           let exitCode: number
           try {


### PR DESCRIPTION
Fix #135 
This pull request enhances the build system by introducing venv-aware build rule selection, improving logging for build steps, and expanding the supported build rules in `media/build-rules.json`. The changes make it easier to work with both venv and local toolchains, and provide clearer diagnostics during builds.

**Build rule selection and detection improvements:**
- Added logic in `BuildService` to prefer venv-aware build rules (such as `cmake` or `c-gcc`) when a virtual environment is active, and fall back to local variants (`cmake-local`, `c-gcc-local`) otherwise. This ensures the correct toolchain is used based on the current environment.
- Updated build system detection to use the selected venv-aware rule and improved logging to indicate which rule and indicator triggered the detection. [[1]](diffhunk://#diff-54c7e3b2ef9692e441b189350a23c2a60dd00f1caff3c358feae97e7cd15ebccL179-R221) [[2]](diffhunk://#diff-54c7e3b2ef9692e441b189350a23c2a60dd00f1caff3c358feae97e7cd15ebccL190-R233)

**Build step logging enhancements:**
- Added a helper method to format and log the exact command line for each build step, making it easier to debug build issues. The working directory and command are now output before each step runs. [[1]](diffhunk://#diff-54c7e3b2ef9692e441b189350a23c2a60dd00f1caff3c358feae97e7cd15ebccR126-R165) [[2]](diffhunk://#diff-54c7e3b2ef9692e441b189350a23c2a60dd00f1caff3c358feae97e7cd15ebccR296-R298)

**Build rules configuration updates (`media/build-rules.json`):**
- Updated the `cmake` rule to use environment-specific toolchain and sysroot paths, and added a corresponding `Build` step. Introduced a `cmake-local` rule for local builds without venv.
- Added a `c-gcc-local` rule for compiling C files with the local GCC toolchain, mirroring the existing `c-gcc` rule for venv environments.

## Summary by Sourcery

Improve build system detection and logging with virtual-environment-aware rule selection.

Enhancements:
- Add virtual-environment-aware selection of build rules, preferring venv or local variants based on the active environment and logging the chosen rule and trigger.
- Log the working directory and a formatted command line for each build step to make build execution more transparent.
- Extend build rule configuration to distinguish between venv and local toolchains for CMake and GCC-based C builds.