### PR TITLE
feat: add initial broad-docs automation support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1080,6 +1080,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.2.tgz",
       "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -1693,6 +1694,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3519,6 +3521,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8416,6 +8419,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -139,6 +139,11 @@
     },
     "commands": [
       {
+        "command": "ruyi.board-docs",
+        "title": "Show Board Docs",
+        "category": "Ruyi"
+      },
+      {
         "command": "ruyi.setup.detect",
         "title": "Detect Ruyi Installation",
         "category": "Ruyi"

--- a/src/board-docs/board-docs-copilot.provider.ts
+++ b/src/board-docs/board-docs-copilot.provider.ts
@@ -1,0 +1,35 @@
+import * as vscode from 'vscode'
+
+import { logger } from '../common/logger'
+
+async function loadDocument(url: string): Promise<string | undefined> {
+  try {
+    const res = await fetch(url)
+    if (!res.ok) {
+      logger.error(`Failed to load document from ${url}: `, res.statusText)
+      return undefined
+    }
+    return res.text()
+  }
+  catch (error) {
+    logger.error(`Failed to load ${url}: `, error)
+    return undefined
+  }
+}
+
+function craftPrompt(document: string): string {
+  return 'The following message is a document that describes few operations that can be done on a RISC-V board:\n\n'
+    + document
+}
+
+export async function openInCopilot(document_url: string) {
+  const document = await loadDocument(document_url)
+  if (!document) {
+    return
+  }
+  const query = craftPrompt(document)
+  vscode.commands.executeCommand('workbench.action.chat.open', {
+    query,
+    isPartialQuery: true,
+  })
+}

--- a/src/board-docs/board-docs-webview.provider.ts
+++ b/src/board-docs/board-docs-webview.provider.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+import * as vscode from 'vscode'
+
+import * as copilot from './board-docs-copilot.provider'
+
+let panel: vscode.WebviewPanel | undefined
+
+export function showBoardDocsPanel(ctx: vscode.ExtensionContext) {
+  if (panel) {
+    panel.reveal(vscode.ViewColumn.One)
+    return
+  }
+
+  panel = vscode.window.createWebviewPanel('ruyiBoardDocs', 'RuyiSDK Board Docs', vscode.ViewColumn.One, {
+    enableScripts: true,
+  })
+
+  panel.onDidDispose(() => {
+    panel = undefined
+  }, null, ctx.subscriptions)
+  panel.webview.onDidReceiveMessage(handleMessage, undefined, ctx.subscriptions)
+  panel.webview.html = getHtml()
+}
+
+async function handleMessage(msg: { type: string, url: string, model: string, profile: string }) {
+  if (msg.type == 'copilot') {
+    copilot.openInCopilot(msg.url)
+  }
+}
+
+function getHtml(): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+      body, html { margin: 0; padding: 0; height: 100%; overflow: hidden; }
+      iframe { border: none; width: 100%; height: 100%; }
+  </style>
+</head>
+<body>
+  <iframe src="https://board-docs-frontend.pages.dev/" id="board-docs-iframe"></iframe>
+  <script lang="javascript">
+    const vscode = acquireVsCodeApi();
+    window.addEventListener('message', event => {
+      vscode.postMessage(event.data);
+    });
+  </script>
+</body>
+</html>`
+}

--- a/src/board-docs/board-docs.command.ts
+++ b/src/board-docs/board-docs.command.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+import * as vscode from 'vscode'
+
+import * as provider from './board-docs-webview.provider'
+
+export default function registerBoardDocsCommands(ctx: vscode.ExtensionContext) {
+  ctx.subscriptions.push(
+    vscode.commands.registerCommand('ruyi.board-docs', () => provider.showBoardDocsPanel(ctx)),
+  )
+}

--- a/src/board-docs/index.ts
+++ b/src/board-docs/index.ts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+import * as vscode from 'vscode'
+
+import registerBoardDocsCommands from './board-docs.command'
+
+export default function registerBoardDocsModule(ctx: vscode.ExtensionContext) {
+  registerBoardDocsCommands(ctx)
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,7 @@
 
 import * as vscode from 'vscode'
 
+import registerBoardDocsModule from './board-docs'
 import registerBuildModule from './build'
 import { configuration } from './common/configuration'
 import { logger } from './common/logger'
@@ -47,6 +48,7 @@ export function activate(context: vscode.ExtensionContext) {
   registerNewsModule(context)
   registerVenvModule(context)
   registerBuildModule(context)
+  registerBoardDocsModule(context)
 
   // Initialize logger
   logger.initialize('RuyiSDK')


### PR DESCRIPTION
This PR adds support for broad-docs-frontend automation, which allows viewing it in
VSCode and automating Copilot interaction by pressing the 'Open in VSCode' button.

New command `ruyi.board-docs` is added.

NOTE: A pending change in the `broad-docs-frontend` is expected to make this patch work.

## Summary by Sourcery

Add a new VS Code webview panel and command to display Ruyi board documentation and integrate it with GitHub Copilot chat.

New Features:
- Introduce the `ruyi.board-docs` command to open a board documentation webview within VS Code.
- Embed the external board-docs frontend site in a VS Code webview panel for in-editor viewing.
- Enable sending selected board documentation content to GitHub Copilot chat via an automated prompt.

Enhancements:
- Wire the new board docs module into the extension activation flow so it is available when the extension loads.