### PR TITLE
feat: package selection for venv sysroot

### DIFF
--- a/src/venv/create.command.ts
+++ b/src/venv/create.command.ts
@@ -22,12 +22,16 @@ type EmulatorPick = vscode.QuickPickItem & {
   noBinary: boolean
 }
 
+type SysrootPkgPick = vscode.QuickPickItem & InstallableDependency
+
 type InstallableDependency = {
   rawName: string
   version: string
   latest: boolean
   installed: boolean
 }
+
+class CancelledError extends Error {}
 
 function buildPackageSpec(pkg: Pick<InstallableDependency, 'rawName' | 'version' | 'latest'>): string {
   if (pkg.latest || !pkg.version) {
@@ -216,9 +220,16 @@ export async function createVenvCommand(service: VenvService): Promise<void> {
   const venvPath = pathInput.trim()
 
   // 6. Sysroot (Optional)
-  const sysrootFrom = await vscode.window.showInputBox({
-    placeHolder: '(Optional) Specify sysroot package. Press enter without input for default. Or ESC to skip.',
-  })
+  let sysrootFrom: string | undefined
+  try {
+    sysrootFrom = await selectSysroot(service)
+  }
+  catch (error) {
+    if (error instanceof CancelledError) {
+      return
+    }
+    throw error
+  }
 
   // 7. Extra Commands (Optional)
   const extraCommands: string[] = []
@@ -302,6 +313,64 @@ export async function createVenvCommand(service: VenvService): Promise<void> {
       )
     }
   }
+}
+
+async function selectSysroot(service: VenvService): Promise<string | undefined> {
+  const withSysroot = await vscode.window.showQuickPick(
+    [{ label: 'Disabled' }, { label: 'Default' }, { label: 'Select a Package' }],
+    { placeHolder: 'Include a sysroot in the new venv?' },
+  )
+
+  if (withSysroot?.label === 'Select a Package') {
+    const sysrootPkgsResult = await service.getSysrootPkgs()
+    if ('errorMsg' in sysrootPkgsResult) {
+      vscode.window.showErrorMessage(sysrootPkgsResult.errorMsg)
+      throw new CancelledError()
+    }
+
+    const sysrootItems: SysrootPkgPick[] = sysrootPkgsResult.map((sp) => {
+      const isLatest = sp.remarks.includes('latest')
+      const isInstalled = sp.remarks.includes('installed')
+
+      const icons = [
+        isLatest ? '$(star-full)' : '',
+        isInstalled ? '$(check)' : '',
+      ].filter(Boolean).join(' ')
+
+      return {
+        label: [icons, sp.name].filter(Boolean).join(' '),
+        description: sp.semver ? `v${sp.semver}` : undefined,
+        detail: [
+          isLatest ? 'Latest' : 'Legacy',
+          isInstalled ? 'Installed' : undefined,
+        ].filter(Boolean).join('   '),
+        rawName: sp.name,
+        version: sp.semver,
+        latest: isLatest,
+        installed: isInstalled,
+      }
+    })
+
+    const pickedSysroot = await vscode.window.showQuickPick(sysrootItems, {
+      placeHolder: 'Select a sysroot (Star=Latest, Check=Installed)',
+      matchOnDescription: true,
+      matchOnDetail: true,
+    })
+
+    if (!pickedSysroot) {
+      throw new CancelledError()
+    }
+
+    return buildPackageSpec(pickedSysroot)
+  }
+  else if (withSysroot?.label === 'Default') {
+    return ''
+  }
+  else if (withSysroot?.label === 'Disabled') {
+    return undefined
+  }
+
+  throw new CancelledError()
 }
 
 /**

--- a/src/venv/emulator.helper.ts
+++ b/src/venv/emulator.helper.ts
@@ -6,49 +6,13 @@
  * These functions return data only and do NOT update global state or UI.
  */
 
-import { parseNDJSON } from '../common/helpers'
 import { logger } from '../common/logger'
 import ruyi from '../ruyi'
-import type { RuyiListOutput } from '../ruyi/types'
 
-import type { EmulatorInfo, EmulatorResult } from './types'
+import type { PkgInfo as EmulatorInfo, EmulatorResult } from './types'
+import { parsePkgs } from './venv.helper'
 
 export type { EmulatorInfo, EmulatorResult }
-
-/**
- * Parses the raw stdout from `ruyi list --porcelain` command to extract emulator information.
- * Filters and transforms the NDJSON output into a structured array of EmulatorInfo objects.
- *
- * @param output - Raw NDJSON output from ruyi list command
- * @returns Array of EmulatorInfo objects
- */
-export function parseEmulators(output: string): EmulatorInfo[] {
-  const result: EmulatorInfo[] = []
-
-  // Use parseNDJSON helper to parse newline-delimited JSON
-  const objects = parseNDJSON<RuyiListOutput>(output)
-
-  for (const obj of objects) {
-    const name = obj.name || ''
-
-    // vers is an array to be iterated
-    if (Array.isArray(obj.vers)) {
-      for (const v of obj.vers) {
-        const semver = v.semver || ''
-        // remarks is always an array based on actual CLI output
-        const remarks = (v.remarks || []).join(', ')
-
-        result.push({
-          name,
-          semver,
-          remarks,
-        })
-      }
-    }
-  }
-
-  return result
-}
 
 /**
  * Fetches all available Ruyi emulators from the ruyi CLI.
@@ -59,7 +23,7 @@ export async function getEmulatorsFromRuyi(): Promise<EmulatorResult> {
   const result = await ruyi.list({ categoryIs: 'emulator' })
 
   if (result.code === 0) {
-    return parseEmulators(result.stdout)
+    return parsePkgs(result.stdout)
   }
   else {
     const errorMsg = `Failed to get emulators: ${result.stderr}`

--- a/src/venv/sysroot.helper.ts
+++ b/src/venv/sysroot.helper.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * RuyiSDK VS Code Extension - Venv Module - Sysroot Helper
+ *
+ * Provides stateless helper functions to deal with sysroot packages or custom sysroots.
+ * These functions return data only and do NOT update global state or UI.
+ */
+
+import { logger } from '../common/logger'
+import ruyi from '../ruyi'
+
+import { SysrootPkgResult } from './types'
+import { parsePkgs } from './venv.helper'
+
+/**
+ * Fetches all available Ruyi packages that can be used as a sysroot from the ruyi CLI.
+ *
+ * @returns Promise resolving to an array of SysrootPkgInfo objects, or an error object on failure
+ */
+export async function getSysrootPkgsFromRuyi(): Promise<SysrootPkgResult> {
+  // TODO: Not all `toolchain` packages contains a sysroot, but Ruyi has not provided a way to check
+  // it yet.
+  const result = await ruyi.list({ categoryIs: 'toolchain' })
+
+  if (result.code === 0) {
+    return parsePkgs(result.stdout)
+  }
+  else {
+    const errorMsg = `Failed to get sysroot packages: ${result.stderr}`
+    logger.error(errorMsg)
+    return { errorMsg }
+  }
+}

--- a/src/venv/types.ts
+++ b/src/venv/types.ts
@@ -37,12 +37,12 @@ export interface Toolchain {
 }
 
 /**
- * Represents a Ruyi emulator package.
+ * Represents a Ruyi package.
  */
-export interface EmulatorInfo {
-  /** Emulator package name */
+export interface PkgInfo {
+  /** Package name */
   name: string
-  /** Semantic version of the emulator */
+  /** Semantic version of the package */
   semver: string
   /** Installation status remarks */
   remarks: string
@@ -74,4 +74,9 @@ export type ProfilesMap = Record<string, string | undefined>
 /**
  * Result type for emulator fetching that can be either success or error.
  */
-export type EmulatorResult = EmulatorInfo[] | { errorMsg: string }
+export type EmulatorResult = PkgInfo[] | { errorMsg: string }
+
+/**
+ * Result type for sysroot package fetching that can be either success or error.
+ */
+export type SysrootPkgResult = PkgInfo[] | { errorMsg: string }

--- a/src/venv/venv.helper.ts
+++ b/src/venv/venv.helper.ts
@@ -5,7 +5,7 @@ import { logger } from '../common/logger'
 import ruyi from '../ruyi'
 import type { RuyiListOutput } from '../ruyi/types'
 
-import type { Toolchain } from './types'
+import type { PkgInfo, Toolchain } from './types'
 
 export type { Toolchain }
 
@@ -68,4 +68,39 @@ export async function getToolchainsFromRuyi(): Promise<Toolchain[]> {
 
   logger.error(`Failed to get toolchains: ${result.stderr}`)
   throw new Error(`Failed to get toolchains: ${result.stderr}`)
+}
+
+/**
+ * Parses the raw stdout from `ruyi list --porcelain` command to extract package information.
+ * Filters and transforms the NDJSON output into a structured array of PkgInfo objects.
+ *
+ * @param output - Raw NDJSON output from ruyi list command
+ * @returns Array of PkgInfo objects
+ */
+export function parsePkgs(output: string): PkgInfo[] {
+  const result: PkgInfo[] = []
+
+  // Use parseNDJSON helper to parse newline-delimited JSON
+  const objects = parseNDJSON<RuyiListOutput>(output)
+
+  for (const obj of objects) {
+    const name = obj.name || ''
+
+    // vers is an array to be iterated
+    if (Array.isArray(obj.vers)) {
+      for (const v of obj.vers) {
+        const semver = v.semver || ''
+        // remarks is always an array based on actual CLI output
+        const remarks = (v.remarks || []).join(', ')
+
+        result.push({
+          name,
+          semver,
+          remarks,
+        })
+      }
+    }
+  }
+
+  return result
 }

--- a/src/venv/venv.service.ts
+++ b/src/venv/venv.service.ts
@@ -17,11 +17,13 @@ import ruyi from '../ruyi'
 import { scanWorkspaceForVenvs } from './detection.helper'
 import { getEmulatorsFromRuyi } from './emulator.helper'
 import { getProfilesFromRuyi } from './profile.helper'
+import { getSysrootPkgsFromRuyi } from './sysroot.helper'
 import type {
   VenvInfo,
   Toolchain,
   EmulatorResult,
   ProfilesMap,
+  SysrootPkgResult,
 } from './types'
 import { getToolchainsFromRuyi } from './venv.helper'
 
@@ -106,6 +108,13 @@ export class VenvService implements vscode.Disposable {
    */
   public async getEmulators(): Promise<EmulatorResult> {
     return getEmulatorsFromRuyi()
+  }
+
+  /**
+   * Gets available Ruyi sysroot packages.
+   */
+  public async getSysrootPkgs(): Promise<SysrootPkgResult> {
+    return getSysrootPkgsFromRuyi()
   }
 
   /**


### PR DESCRIPTION
Adds package selection for venv sysroot, fixing #144.

This also makes improves code structure asking for sysroot, to more easily introduce support of custom sysroot paths in the future, since latest Ruyi alpha introduced that feature.

## Summary by Sourcery

Add interactive selection of sysroot packages when creating a venv and generalize package parsing and types to support both emulators and sysroots.

New Features:
- Allow users to choose between no sysroot, the default sysroot, or a specific sysroot package when creating a virtual environment.

Bug Fixes:
- Fix the previous free-form sysroot input by replacing it with validated package-based selection to resolve incorrect sysroot specifications.

Enhancements:
- Introduce a shared package parsing helper and generic package info type reused by emulator and sysroot handling.
- Expose sysroot package retrieval via the venv service for future custom sysroot support.