### PR TITLE
build: bump version to 0.1.4-beta.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ruyisdk-vscode-extension",
-  "version": "0.1.4-beta.1",
+  "version": "0.1.4-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ruyisdk-vscode-extension",
-      "version": "0.1.4-beta.1",
+      "version": "0.1.4-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
         "semver": "^7.7.3"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ruyisdk-vscode-extension",
   "displayName": "RuyiSDK",
   "description": "VS Code integration for the Ruyi package manager.",
-  "version": "0.1.4-beta.1",
+  "version": "0.1.4-beta.2",
   "publisher": "RuyiSDK",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update package.json and lockfile metadata to reflect the 0.1.4-beta.2 version.