### PR TITLE
fix: venv-create mischecked '' as undefined

### DIFF
--- a/src/venv/create.command.ts
+++ b/src/venv/create.command.ts
@@ -278,8 +278,7 @@ export async function createVenvCommand(service: VenvService): Promise<void> {
           path: venvPath,
           toolchains: toolchainSpecs,
           emulator: emulatorSpec,
-          // Enter -> true even if input is empty str; ESC -> false.
-          withSysroot: !!(copySysrootFromPkg ?? copySysrootFromDir ?? symlinkSysrootFromDir),
+          withSysroot: (copySysrootFromPkg ?? copySysrootFromDir ?? symlinkSysrootFromDir) !== undefined,
           copySysrootFromPkg,
           copySysrootFromDir,
           symlinkSysrootFromDir,


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix venv creation logic that incorrectly treated empty-string sysroot configuration values as undefined when deciding whether to enable sysroot handling.