### PR TITLE
feat: allow suppressing ruyi detect message on launch

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -92,6 +92,7 @@
   "Select RuyiSDK installation": "Select RuyiSDK installation",
   "Ruyi found at {0} but version check failed. Please check your installation.": "Ruyi found at {0} but version check failed. Please check your installation.",
   "Ruyi detected: {0} ({1})": "Ruyi detected: {0} ({1})",
+  "Don't show again": "Don't show again",
   "Failed to execute command": "Failed to execute command",
   "Command timed out": "Command timed out",
   "Uninstall {0} {1}?": "Uninstall {0} {1}?",

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -92,6 +92,7 @@
   "Select RuyiSDK installation": "选择 RuyiSDK 安装位置",
   "Ruyi found at {0} but version check failed. Please check your installation.": "在 {0} 找到 Ruyi，但版本检查失败。请检查您的安装。",
   "Ruyi detected: {0} ({1})": "检测到 Ruyi：{0}（{1}）",
+  "Don't show again": "不再提示",
   "Failed to execute command": "执行命令失败",
   "Command timed out": "命令超时",
   "Uninstall {0} {1}?": "确认卸载 {0} {1}？",

--- a/package.json
+++ b/package.json
@@ -355,6 +355,11 @@
           "default": "",
           "description": "%contributes.configuration.properties.ruyi.ruyiPath.description%"
         },
+        "ruyi.quietRuyiPath": {
+          "type": "boolean",
+          "default": false,
+          "description": "%contributes.configuration.properties.ruyi.quietRuyiPath.description%"
+        },
         "ruyi.telemetry": {
           "type": "boolean",
           "description": "%contributes.configuration.properties.ruyi.telemetry.description%"

--- a/package.nls.json
+++ b/package.nls.json
@@ -44,5 +44,6 @@
     "contributes.commands.ruyi.build.run.title": "Build Project",
     "contributes.configuration.properties.ruyi.checkForUpdates.description": "Automatically check for Ruyi updates when running detect command.",
     "contributes.configuration.properties.ruyi.ruyiPath.description": "Path to RuyiSDK installation. If not set, will try to detect automatically.",
-    "contributes.configuration.properties.ruyi.telemetry.description": "Enable telemetry collection to help improve RuyiSDK. Leave unset to be prompted on first use."
+    "contributes.configuration.properties.ruyi.telemetry.description": "Enable telemetry collection to help improve RuyiSDK. Leave unset to be prompted on first use.",
+    "contributes.configuration.properties.ruyi.quietRuyiPath.description": "Suppress successful Ruyi path check message on every VSCode start."
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -44,5 +44,6 @@
     "contributes.commands.ruyi.build.run.title": "Build Project",
     "contributes.configuration.properties.ruyi.checkForUpdates.description": "运行检测命令时自动检测 Ruyi 更新。",
     "contributes.configuration.properties.ruyi.ruyiPath.description": "RuyiSDK 安装路径。如果未设置，将尝试自动检测。",
-    "contributes.configuration.properties.ruyi.telemetry.description": "启用遥测收集以帮助改进 RuyiSDK。未设置时将在首次使用时提示。"
+    "contributes.configuration.properties.ruyi.telemetry.description": "启用遥测收集以帮助改进 RuyiSDK。未设置时将在首次使用时提示。",
+    "contributes.configuration.properties.ruyi.quietRuyiPath.description": "如果 Ruyi 路径检查成功，不要在每次 VSCode 启动时显示消息。"
 }

--- a/src/common/configuration.ts
+++ b/src/common/configuration.ts
@@ -44,6 +44,10 @@ class ConfigurationService implements vscode.Disposable {
     return this.get(CONFIG_KEYS.CHECK_FOR_UPDATES, true)
   }
 
+  public get quietRuyiPath(): boolean {
+    return this.get(CONFIG_KEYS.QUIET_RUYI_PATH, false)
+  }
+
   public get ruyiPath(): string | undefined {
     const path = this.get(CONFIG_KEYS.RUYI_PATH, '')
     return path.trim() || undefined
@@ -56,6 +60,10 @@ class ConfigurationService implements vscode.Disposable {
 
   public async setTelemetry(enabled: boolean): Promise<void> {
     await this.config.update(CONFIG_KEYS.TELEMETRY, enabled, true)
+  }
+
+  public async setQuietRuyiPath(enabled: boolean): Promise<void> {
+    await this.config.update(CONFIG_KEYS.QUIET_RUYI_PATH, enabled, true)
   }
 
   public reload(): void {

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -11,6 +11,7 @@ export type ConfigKey = typeof CONFIG_KEYS[keyof typeof CONFIG_KEYS]
 /** Configuration keys */
 export const CONFIG_KEYS = {
   CHECK_FOR_UPDATES: 'checkForUpdates',
+  QUIET_RUYI_PATH: 'quietRuyiPath',
   RUYI_PATH: 'ruyiPath',
   TELEMETRY: 'telemetry',
 } as const

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,7 +63,7 @@ export function activate(context: vscode.ExtensionContext) {
         await vscode.commands.executeCommand('ruyi.home.show')
       }
 
-      await vscode.commands.executeCommand('ruyi.setup.detect')
+      await vscode.commands.executeCommand('ruyi.setup.detect', true)
       await vscode.commands.executeCommand('ruyi.venv.refresh')
     }
     catch (error) {

--- a/src/setup/manage.command.ts
+++ b/src/setup/manage.command.ts
@@ -119,7 +119,7 @@ export function registerManageCommand(ctx: vscode.ExtensionContext): void {
 }
 
 export function registerDetectCommand(ctx: vscode.ExtensionContext): void {
-  const disposable = vscode.commands.registerCommand('ruyi.setup.detect', async () => {
+  const disposable = vscode.commands.registerCommand('ruyi.setup.detect', async (auto?: boolean) => {
     const installation = await detectRuyiInstallation()
 
     if (!installation) {
@@ -135,9 +135,18 @@ export function registerDetectCommand(ctx: vscode.ExtensionContext): void {
       return
     }
 
-    vscode.window.showInformationMessage(
-      vscode.l10n.t('Ruyi detected: {0} ({1})', installation.version, installation.path),
-    )
+    if (!auto || !configuration.quietRuyiPath) {
+      const message = vscode.l10n.t('Ruyi detected: {0} ({1})', installation.version, installation.path)
+      if (auto) {
+        const result = await vscode.window.showInformationMessage(message, vscode.l10n.t('Don\'t show again'))
+        if (result === vscode.l10n.t('Don\'t show again')) {
+          await configuration.setQuietRuyiPath(true)
+        }
+      }
+      else {
+        vscode.window.showInformationMessage(message)
+      }
+    }
 
     await vscode.commands.executeCommand('setContext', 'ruyi.tutorial.installationComplete', true)
 


### PR DESCRIPTION
## Summary by Sourcery

Add a configurable option to suppress automatic Ruyi detection messages on extension startup.

New Features:
- Introduce a quietRuyiPath user setting to control whether automatically triggered Ruyi detection notifications are shown.

Enhancements:
- Update the Ruyi detection command to support an automatic mode that can respect the quietRuyiPath preference and offer a one-click opt-out from future auto-detect notifications.

Documentation:
- Document the new ruyi.quietRuyiPath configuration option in the extension manifest localization files.