### PR TITLE
feat: support ruyi 0.49 sysroot projection

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -37,6 +37,7 @@
   "Select a Package": "Select a Package",
   "Copy from Directory": "Copy from Directory",
   "Symlink from Directory": "Symlink from Directory",
+  "Project from Directory": "Project from Directory",
   "Include a sysroot in the new venv?": "Include a sysroot in the new venv?",
   "Select a sysroot (Star=Latest, Check=Installed)": "Select a sysroot (Star=Latest, Check=Installed)",
   "Invalid virtual environment: no path found.": "Invalid virtual environment: no path found.",

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -37,6 +37,7 @@
   "Select a Package": "选择一个软件包",
   "Copy from Directory": "从目录复制",
   "Symlink from Directory": "从目录创建符号链接",
+  "Project from Directory": "从目录投射",
   "Include a sysroot in the new venv?": "是否在新建的虚拟环境中包含 sysroot？",
   "Select a sysroot (Star=Latest, Check=Installed)": "选择 sysroot（星标=最新版，对勾=已安装）",
   "Invalid virtual environment: no path found.": "无效的虚拟环境：未找到路径。",

--- a/src/ruyi/index.ts
+++ b/src/ruyi/index.ts
@@ -116,6 +116,7 @@ export interface VenvOptions {
   copySysrootFromPkg?: string
   copySysrootFromDir?: string
   symlinkSysrootFromDir?: string
+  projectSysrootFromRootfs?: string
   extraCommandsFrom?: string | string[]
 }
 
@@ -526,6 +527,9 @@ export class Ruyi {
     }
     if (options?.copySysrootFromDir) {
       args.push('--copy-sysroot-from-dir', options.copySysrootFromDir)
+    }
+    if (options?.projectSysrootFromRootfs) {
+      args.push('--project-sysroot-from-rootfs', options.projectSysrootFromRootfs)
     }
     if (options?.symlinkSysrootFromDir) {
       args.push('--symlink-sysroot-from-dir', options.symlinkSysrootFromDir)

--- a/src/venv/create.command.ts
+++ b/src/venv/create.command.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode'
 import { getWorkspaceFolderPath } from '../common/helpers'
 import { installPackage } from '../packages/install.command'
 
+import { ruyiVersionIsAbove } from './venv.helper'
 import type { VenvService } from './venv.service'
 
 type ToolchainPick = vscode.QuickPickItem & {
@@ -25,7 +26,7 @@ type EmulatorPick = vscode.QuickPickItem & {
 type SysrootPkgPick = vscode.QuickPickItem & InstallableDependency
 
 type SelectedSysroot = {
-  kind: 'pkg' | 'copy-dir' | 'symlink-dir'
+  kind: 'pkg' | 'copy-dir' | 'symlink-dir' | 'project-dir'
   data: string
 }
 
@@ -237,6 +238,7 @@ export async function createVenvCommand(service: VenvService): Promise<void> {
   let copySysrootFromPkg: string | undefined
   let copySysrootFromDir: string | undefined
   let symlinkSysrootFromDir: string | undefined
+  let projectSysrootFromRootfs: string | undefined
   try {
     const selectedSysroot = await selectSysroot(service)
     if (selectedSysroot?.kind == 'pkg') {
@@ -247,6 +249,9 @@ export async function createVenvCommand(service: VenvService): Promise<void> {
     }
     else if (selectedSysroot?.kind == 'symlink-dir') {
       symlinkSysrootFromDir = selectedSysroot.data
+    }
+    else if (selectedSysroot?.kind == 'project-dir') {
+      projectSysrootFromRootfs = selectedSysroot.data
     }
   }
   catch (error) {
@@ -287,10 +292,11 @@ export async function createVenvCommand(service: VenvService): Promise<void> {
           path: venvPath,
           toolchains: toolchainSpecs,
           emulator: emulatorSpec,
-          withSysroot: (copySysrootFromPkg ?? copySysrootFromDir ?? symlinkSysrootFromDir) !== undefined,
+          withSysroot: (copySysrootFromPkg ?? copySysrootFromDir ?? symlinkSysrootFromDir ?? projectSysrootFromRootfs) !== undefined,
           copySysrootFromPkg,
           copySysrootFromDir,
           symlinkSysrootFromDir,
+          projectSysrootFromRootfs,
           extraCommandsFrom: extraCommands.length > 0 ? extraCommands : undefined,
         }, progress)
 
@@ -342,14 +348,19 @@ export async function createVenvCommand(service: VenvService): Promise<void> {
 }
 
 async function selectSysroot(service: VenvService): Promise<SelectedSysroot | undefined> {
+  const availableWays = [
+    { id: 'disabled', label: vscode.l10n.t('Disabled') },
+    { id: 'default', label: vscode.l10n.t('Default') },
+    { id: 'pkg', label: vscode.l10n.t('Select a Package') },
+    { id: 'copy-dir', label: vscode.l10n.t('Copy from Directory') },
+    { id: 'symlink-dir', label: vscode.l10n.t('Symlink from Directory') },
+  ]
+  if (await ruyiVersionIsAbove('0.49.0')) {
+    availableWays.push({ id: 'project-dir', label: vscode.l10n.t('Project from Directory') })
+  }
+
   const withSysroot = await vscode.window.showQuickPick(
-    [
-      { id: 'disabled', label: vscode.l10n.t('Disabled') },
-      { id: 'default', label: vscode.l10n.t('Default') },
-      { id: 'pkg', label: vscode.l10n.t('Select a Package') },
-      { id: 'copy-dir', label: vscode.l10n.t('Copy from Directory') },
-      { id: 'symlink-dir', label: vscode.l10n.t('Symlink from Directory') },
-    ],
+    availableWays,
     { placeHolder: vscode.l10n.t('Include a sysroot in the new venv?') },
   )
 
@@ -366,6 +377,14 @@ async function selectSysroot(service: VenvService): Promise<SelectedSysroot | un
 
     return {
       kind: 'symlink-dir',
+      data: path,
+    }
+  }
+  else if (withSysroot?.id === 'project-dir') {
+    const path = await selectSysrootDir()
+
+    return {
+      kind: 'project-dir',
       data: path,
     }
   }

--- a/src/venv/venv.helper.ts
+++ b/src/venv/venv.helper.ts
@@ -70,6 +70,25 @@ export async function getToolchainsFromRuyi(): Promise<Toolchain[]> {
   throw new Error(`Failed to get toolchains: ${result.stderr}`)
 }
 
+export async function ruyiVersionIsAbove(expected: string): Promise<boolean> {
+  const result = await ruyi.version()
+  if (!result) {
+    return false
+  }
+
+  const actual = result.split('-')[0].split('+')[0]
+  const [actualMajor, actualMinor, actualPatch] = actual.split('.').map(Number)
+  const [expectedMajor, expectedMinor, expectedPatch] = expected.split('.').map(Number)
+
+  if (actualMajor > expectedMajor) return true
+  if (actualMajor < expectedMajor) return false
+
+  if (actualMinor > expectedMinor) return true
+  if (actualMinor < expectedMinor) return false
+
+  return actualPatch >= expectedPatch
+}
+
 /**
  * Parses the raw stdout from `ruyi list --porcelain` command to extract package information.
  * Filters and transforms the NDJSON output into a structured array of PkgInfo objects.

--- a/src/venv/venv.service.ts
+++ b/src/venv/venv.service.ts
@@ -35,6 +35,7 @@ export interface VenvCreateParams {
   withSysroot?: boolean
   copySysrootFromPkg?: string
   copySysrootFromDir?: string
+  projectSysrootFromRootfs?: string
   symlinkSysrootFromDir?: string
   extraCommandsFrom?: string[]
 }
@@ -214,7 +215,7 @@ export class VenvService implements vscode.Disposable {
    * Creates a new virtual environment.
    */
   public async createVenv(params: VenvCreateParams, progressReporter?: vscode.Progress<{ message?: string, increment?: number }>): Promise<boolean> {
-    const { profile, path: venvPath, toolchains, emulator, withSysroot, copySysrootFromPkg, copySysrootFromDir, symlinkSysrootFromDir, extraCommandsFrom } = params
+    const { profile, path: venvPath, toolchains, emulator, withSysroot, copySysrootFromPkg, copySysrootFromDir, symlinkSysrootFromDir, extraCommandsFrom, projectSysrootFromRootfs } = params
 
     try {
       let getLastPercent: (() => number) | undefined
@@ -235,6 +236,7 @@ export class VenvService implements vscode.Disposable {
         copySysrootFromPkg,
         copySysrootFromDir,
         symlinkSysrootFromDir,
+        projectSysrootFromRootfs,
         extraCommandsFrom,
       })
 


### PR DESCRIPTION
## Summary by Sourcery

Add support for projecting a sysroot from a project directory when creating virtual environments with Ruyi.

New Features:
- Allow selecting a project directory as a sysroot source during virtual environment creation.
- Propagate the selected project-rootfs sysroot option through venv creation parameters to the Ruyi CLI invocation.