### PR TITLE
feat: improve board-docs error hints

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -179,5 +179,7 @@
   "Click to build the project.": "Click to build the project.",
   "Venv": "Venv",
   "build tools from the virtual environment will be used.": "build tools from the virtual environment will be used.",
-  "No active venv — system build tools will be used.": "No active venv — system build tools will be used."
+  "No active venv — system build tools will be used.": "No active venv — system build tools will be used.",
+  "Network Unavailable": "Network Unavailable",
+  "To use RuyiSDK Examples, you must be connected to the Internet.": "To use RuyiSDK Examples, you must be connected to the Internet."
 }

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -179,5 +179,7 @@
   "Click to build the project.": "点击构建项目。",
   "Venv": "虚拟环境",
   "build tools from the virtual environment will be used.": "将使用虚拟环境中的构建工具。",
-  "No active venv — system build tools will be used.": "未激活虚拟环境 — 将使用系统构建工具。"
+  "No active venv — system build tools will be used.": "未激活虚拟环境 — 将使用系统构建工具。",
+  "Network Unavailable": "网络不可用",
+  "To use RuyiSDK Examples, you must be connected to the Internet.": "要使用 RuyiSDK 示例，您必须连接到互联网。"
 }

--- a/src/board-docs/board-docs-webview.provider.ts
+++ b/src/board-docs/board-docs-webview.provider.ts
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as vscode from 'vscode'
 
+import { isNetworkAvailable } from '../common/helpers'
+
 import * as copilot from './board-docs-copilot.provider'
 
 let panel: vscode.WebviewPanel | undefined
 
-export function showBoardDocsPanel(ctx: vscode.ExtensionContext) {
+export async function showBoardDocsPanel(ctx: vscode.ExtensionContext): Promise<void> {
   if (panel) {
     panel.reveal(vscode.ViewColumn.One)
     return
@@ -19,7 +21,12 @@ export function showBoardDocsPanel(ctx: vscode.ExtensionContext) {
     panel = undefined
   }, null, ctx.subscriptions)
   panel.webview.onDidReceiveMessage(handleMessage, undefined, ctx.subscriptions)
-  panel.webview.html = getHtml()
+  if (await isNetworkAvailable()) {
+    panel.webview.html = getHtml()
+  }
+  else {
+    panel.webview.html = getErrorHtml()
+  }
 }
 
 async function handleMessage(msg: { type: string, url: string, model: string, profile: string }) {
@@ -47,6 +54,64 @@ function getHtml(): string {
       vscode.postMessage(event.data);
     });
   </script>
+</body>
+</html>`
+}
+
+function getErrorHtml(): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    body, html {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      background: var(--vscode-editor-background, #1e1e1e);
+      color: var(--vscode-editor-foreground, #cccccc);
+      font-family: var(--vscode-font-family, "Segoe WPC", "Segoe UI", "Ubuntu", sans-serif);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .container {
+      text-align: center;
+      padding: 32px;
+      max-width: 520px;
+    }
+    .icon {
+      font-size: 72px;
+      line-height: 1;
+      margin-bottom: 24px;
+      color: var(--vscode-editorWarning-foreground, #f8bd00);
+    }
+    .title {
+      font-size: 20px;
+      font-weight: 600;
+      margin: 0 0 12px;
+    }
+    .message {
+      font-size: 14px;
+      line-height: 1.6;
+      color: var(--vscode-editor-foreground, #cccccc);
+      margin: 0;
+    }
+    .hint {
+      margin-top: 20px;
+      font-size: 13px;
+      color: var(--vscode-editorHint-foreground, #9e9e9e);
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="icon">⚠️</div>
+    <h1 class="title">${vscode.l10n.t('Network Unavailable')}</h1>
+    <p>${vscode.l10n.t('To use RuyiSDK Examples, you must be connected to the Internet.')}</p>
+  </div>
 </body>
 </html>`
 }

--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -139,3 +139,16 @@ export function parseDownloadProgress(line: string): number | null {
   }
   return null
 }
+
+export async function isNetworkAvailable(): Promise<boolean> {
+  try {
+    await fetch('https://detectportal.firefox.com/success.txt', {
+      method: 'HEAD',
+      signal: AbortSignal.timeout(5000),
+    })
+    return true
+  }
+  catch {
+    return false
+  }
+}

--- a/src/news/news.service.ts
+++ b/src/news/news.service.ts
@@ -12,6 +12,7 @@ import * as os from 'os'
 import * as path from 'path'
 import * as vscode from 'vscode'
 
+import { isNetworkAvailable } from '../common/helpers'
 import { logger } from '../common/logger'
 import ruyi from '../ruyi'
 
@@ -50,19 +51,6 @@ export class NewsService {
       NewsService.instance = new NewsService(context)
     }
     return NewsService.instance
-  }
-
-  private async isNetworkAvailable(): Promise<boolean> {
-    try {
-      await fetch('https://detectportal.firefox.com/success.txt', {
-        method: 'HEAD',
-        signal: AbortSignal.timeout(5000),
-      })
-      return true
-    }
-    catch {
-      return false
-    }
   }
 
   private async loadCache(allowExpired = false): Promise<NewsCache | null> {
@@ -121,7 +109,7 @@ export class NewsService {
   async list(unread = false, forceRefresh = false): Promise<NewsRow[]> {
     // forceRefresh implies trying to update the repo from remote
     if (forceRefresh) {
-      const isOnline = await this.isNetworkAvailable()
+      const isOnline = await isNetworkAvailable()
       if (isOnline) {
         try {
           await this.refreshNewsRepo()
@@ -187,7 +175,7 @@ export class NewsService {
 
   async initialize(): Promise<void> {
     try {
-      const isOnline = await this.isNetworkAvailable()
+      const isOnline = await isNetworkAvailable()
       if (isOnline) {
         await this.list(false, true)
         logger.log('News service initialized')


### PR DESCRIPTION
当使用 board-docs 功能时，若网络不可用，显示一个明显的错误提示，指示用户连接到互联网。

## Summary by Sourcery

Add online connectivity checks for board-docs and centralize network availability detection.

New Features:
- Display a dedicated error webview when board-docs is opened without network connectivity.

Enhancements:
- Reuse a shared network availability helper across board-docs and news services for consistent online checks.