### PR TITLE
feat: make installation manual url match user language

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -50,6 +50,7 @@
   "Disable": "Disable",
   "Ruyi telemetry enabled. Thank you!": "Ruyi telemetry enabled. Thank you!",
   "Ruyi telemetry disabled.": "Ruyi telemetry disabled.",
+  "https://ruyisdk.org/en/docs/Package-Manager/installation": "https://ruyisdk.org/en/docs/Package-Manager/installation",
   "Installation": "Installation",
   "Update": "Update",
   "{0} failed via {1}.": "{0} failed via {1}.",

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -50,6 +50,7 @@
   "Disable": "禁用",
   "Ruyi telemetry enabled. Thank you!": "Ruyi 遥测已启用。感谢您的支持！",
   "Ruyi telemetry disabled.": "Ruyi 遥测已禁用。",
+  "https://ruyisdk.org/en/docs/Package-Manager/installation": "https://ruyisdk.org/docs/Package-Manager/installation",
   "Installation": "安装",
   "Update": "更新",
   "{0} failed via {1}.": "通过 {1} 进行 {0} 失败。",

--- a/src/setup/setup.command.ts
+++ b/src/setup/setup.command.ts
@@ -15,7 +15,7 @@ import {
   type PackageMethod,
 } from './setup.helper'
 
-const INSTALLATION_GUIDE_URL = 'https://ruyisdk.org/en/docs/Package-Manager/installation'
+const INSTALLATION_GUIDE_URL = vscode.l10n.t('https://ruyisdk.org/en/docs/Package-Manager/installation')
 
 function getErrorDetails(error: unknown): string {
   const execError = error as ExecException


### PR DESCRIPTION
目前在无法自动安装时指向的手动安装指南URL打开后始终默认为英语，该PR为该URL添加进i18n，添加中文URL自动适配

## Summary by Sourcery

New Features:
- Make the installation manual URL use VS Code localization so users are directed to a language-appropriate guide.