### PR TITLE
feat: support ruyi 0.50 package size hints

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -152,6 +152,7 @@
   "Latest version": "Latest version",
   "Prerelease version": "Prerelease version",
   "No binary available for current platform": "No binary available for current platform",
+  "Download size: {0}": "Download size: {0}",
   "Install {0} {1}?": "Install {0} {1}?",
   "Installing {0}...": "Installing {0}...",
   "Starting installation...": "Starting installation...",

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -152,6 +152,7 @@
   "Latest version": "最新版本",
   "Prerelease version": "预发布版本",
   "No binary available for current platform": "当前平台无可用二进制文件",
+  "Download size: {0}": "下载的大小：{0}",
   "Install {0} {1}?": "确认安装 {0} {1}？",
   "Installing {0}...": "正在安装 {0}...",
   "Starting installation...": "开始安装...",

--- a/src/packages/package-tree.provider.ts
+++ b/src/packages/package-tree.provider.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode'
 import { logger } from '../common/logger.js'
 import type { PackageCategory } from '../ruyi'
 
+import { formatSize } from './package.helper.js'
 import { RuyiPackage, RuyiPackageVersion, PackageService } from './package.service'
 
 // Define tree node types
@@ -285,7 +286,11 @@ export class VersionItem extends vscode.TreeItem {
     let tooltip = `${this.pkg.name}@${this.versionInfo.version}\n`
 
     if (this.versionInfo.isInstalled) {
-      tooltip += '✓ ' + vscode.l10n.t('Installed') + '\n'
+      tooltip += '✓ ' + vscode.l10n.t('Installed')
+      if (this.versionInfo.installSize) {
+        tooltip += ` (${formatSize(this.versionInfo.installSize)})`
+      }
+      tooltip += '\n'
     }
     if (this.versionInfo.isLatest) {
       tooltip += '⭐ ' + vscode.l10n.t('Latest version') + '\n'
@@ -295,6 +300,9 @@ export class VersionItem extends vscode.TreeItem {
     }
     if (!this.versionInfo.isBinaryAvailable) {
       tooltip += '⚠️ ' + vscode.l10n.t('No binary available for current platform') + '\n'
+    }
+    if (this.versionInfo.downloadSize) {
+      tooltip += '⬇️ ' + vscode.l10n.t('Download size: {0}', formatSize(this.versionInfo.downloadSize)) + '\n'
     }
 
     return tooltip.trim()

--- a/src/packages/package.helper.ts
+++ b/src/packages/package.helper.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export function formatSize(bytes: number): string {
+  if (!isFinite(bytes)) return String(bytes)
+  const units = ['B', 'kB', 'MB', 'GB', 'TB', 'PB']
+  if (bytes === 0) return '0 B'
+  const absBytes = Math.abs(bytes)
+  const idx = Math.min(Math.floor(Math.log10(absBytes) / 3), units.length - 1)
+  const value = bytes / Math.pow(1000, idx)
+  const rounded = Math.round(value) === value ? value.toFixed(0) : value.toFixed(2).replace(/\.?(0+)$/, '')
+  return `${rounded} ${units[idx]}`
+}

--- a/src/packages/package.service.ts
+++ b/src/packages/package.service.ts
@@ -11,6 +11,8 @@ export interface RuyiPackageVersion {
   isLatestPrerelease: boolean
   isInstalled: boolean
   isBinaryAvailable: boolean
+  downloadSize?: number
+  installSize?: number
   slug?: string
 }
 
@@ -149,6 +151,8 @@ export class PackageService {
             isPrerelease,
             isLatestPrerelease,
             isBinaryAvailable: !v.remarks.includes('no-binary-for-current-host'),
+            downloadSize: v.download_size_host_bytes,
+            installSize: v.install_size,
             slug,
           }
         })

--- a/src/ruyi/types.ts
+++ b/src/ruyi/types.ts
@@ -6,6 +6,8 @@ export interface RuyiVersionInfo {
   remarks: string[]
   is_downloaded: boolean
   is_installed: boolean
+  download_size_host_bytes?: number
+  install_size?: number
   pm?: {
     metadata?: {
       desc?: string


### PR DESCRIPTION
支持 Ruyi 0.50 加入的包大小提示功能。

该 PR 不会影响低于 0.50 的 Ruyi 版本，它们仍然会如之前一样正常工作。

## Summary by Sourcery

Add support for displaying Ruyi package download and install size information where available.

New Features:
- Show formatted install size for installed package versions in the package tree tooltip when provided by Ruyi 0.50+.
- Show formatted download size for package versions in the package tree tooltip when provided by Ruyi 0.50+.

Enhancements:
- Extend package and Ruyi version metadata to include optional download and install size fields for future size-aware features.