### PR TITLE
feat: use viewsWelcome for venv tree

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -5,7 +5,6 @@
   "Invalid virtual environment path.": "Invalid virtual environment path.",
   "Open a workspace folder before activating a Ruyi venv.": "Open a workspace folder before activating a Ruyi venv.",
   "Venv creation complete": "Venv creation complete",
-  "No venvs detected": "No venvs detected",
   "Unknown Venv": "Unknown Venv",
   "Active Ruyi Venv: {0}": "Active Ruyi Venv: {0}",
   "No Active Venv": "No Active Venv",

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -5,7 +5,6 @@
   "Invalid virtual environment path.": "无效的虚拟环境路径。",
   "Open a workspace folder before activating a Ruyi venv.": "请先打开一个工作区文件夹，再激活 Ruyi 虚拟环境。",
   "Venv creation complete": "虚拟环境创建完成",
-  "No venvs detected": "未检测到虚拟环境",
   "Unknown Venv": "未知的虚拟环境",
   "Active Ruyi Venv: {0}": "当前激活的 Ruyi 虚拟环境：{0}",
   "No Active Venv": "未激活任何虚拟环境",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,12 @@
         }
       ]
     },
+    "viewsWelcome": [
+      {
+        "view": "ruyiVenvsView",
+        "contents": "%contributes.viewsWelcome.ruyiVenvsView.contents%"
+      }
+    ],
     "views": {
       "ruyi": [
         {

--- a/package.nls.json
+++ b/package.nls.json
@@ -18,6 +18,7 @@
     "contributes.walkthroughs.ruyi.welcome.steps.example.title": "Build example executable",
     "contributes.walkthroughs.ruyi.welcome.steps.example.description": "[Follow our guide](https://ruyisdk.org/en/docs/VSCode-Plugins/cases/case1/) to build a binary and run it on a RISC-V Development Board.",
     "contributes.walkthroughs.ruyi.welcome.steps.example.media.altText": "CoreMark: Build with Extension (Example: LicheePi 4A)",
+    "contributes.viewsWelcome.ruyiVenvsView.contents": "No virtual environments found.\n[Create Virtual Environment](command:ruyi.venv.create)",
     "contributes.views.ruyiPackagesView.name": "RuyiSDK Packages",
     "contributes.views.ruyiVenvsView.name": "RuyiSDK Virtual Environment",
     "contributes.commands.ruyi.board-docs.title": "Show Board Docs",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -18,6 +18,7 @@
     "contributes.walkthroughs.ruyi.welcome.steps.example.title": "构建示例二进制",
     "contributes.walkthroughs.ruyi.welcome.steps.example.description": "[跟着我们的指南](https://ruyisdk.org/en/docs/VSCode-Plugins/cases/case1/) 构建二进制并运行在 RISC-V 开发板上。",
     "contributes.walkthroughs.ruyi.welcome.steps.example.media.altText": "CoreMark: 用扩展构建（例如 LicheePi 4A）",
+    "contributes.viewsWelcome.ruyiVenvsView.contents": "找不到虚拟环境。\n[创建虚拟环境](command:ruyi.venv.create)",
     "contributes.views.ruyiPackagesView.name": "RuyiSDK 软件包",
     "contributes.views.ruyiVenvsView.name": "RuyiSDK 虚拟环境",
     "contributes.commands.ruyi.board-docs.title": "展示开发板文档",

--- a/src/venv/venv-tree.provider.ts
+++ b/src/venv/venv-tree.provider.ts
@@ -7,7 +7,7 @@ import { getWorkspaceFolderPath } from '../common/helpers'
 import type { VenvInfo } from './types'
 import { VenvService } from './venv.service'
 
-type VenvTreeElement = VenvItem | PlaceholderItem
+type VenvTreeElement = VenvItem
 
 export class VenvTreeProvider implements vscode.TreeDataProvider<VenvTreeElement> {
   private static _instance: VenvTreeProvider
@@ -39,9 +39,6 @@ export class VenvTreeProvider implements vscode.TreeDataProvider<VenvTreeElement
     }
 
     const venvs = await this.service.listVenvs()
-    if (!venvs.length) {
-      return [new PlaceholderItem()]
-    }
 
     const current = this.service.getCurrentVenv()
     return venvs.map(venv => new VenvItem(venv, this.isCurrentVenv(venv, current)))
@@ -82,13 +79,5 @@ export class VenvItem extends vscode.TreeItem {
       ? new vscode.ThemeIcon('check', new vscode.ThemeColor('testing.iconPassed'))
       : new vscode.ThemeIcon('file-directory')
     this.resourceUri = vscode.Uri.file(venv.path)
-  }
-}
-
-class PlaceholderItem extends vscode.TreeItem {
-  constructor() {
-    super(vscode.l10n.t('No venvs detected'), vscode.TreeItemCollapsibleState.None)
-    this.iconPath = new vscode.ThemeIcon('info')
-    this.contextValue = 'ruyiVenv.placeholder'
   }
 }


### PR DESCRIPTION
## Summary by Sourcery

Replace the virtual environment tree placeholder item with a viewsWelcome message for the venv view.

New Features:
- Introduce a viewsWelcome message for the virtual environment view when no environments are detected.

Enhancements:
- Simplify the venv tree provider by removing the placeholder tree item in favor of the built-in viewsWelcome UX.

Documentation:
- Add localized strings for the new viewsWelcome content for the venv view.