### PR TITLE
docs: update l10n in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -362,19 +362,42 @@ which fails on Windows. Now using path.join for cross-platform support.
 
 ## Localization
 
-This project supports both English and Chinese. Localization files are in the
-`l10n/` directory:
+This project uses [`vscode-l10n`](https://github.com/microsoft/vscode-l10n) for
+localization. Currently, Chinese and English are supported.
+
+Message files are in the `l10n/` directory:
 
 - `bundle.l10n.json` — English source file
 - `bundle.l10n.zh-cn.json` — Chinese translation
+
+To learn how to add new messages in TypeScript code, see
+[vscode-l10n-dev](https://github.com/microsoft/vscode-l10n/tree/main/l10n-dev).
 
 User-visible strings in `package.json` are localized via:
 
 - `package.nls.json` — English
 - `package.nls.zh-cn.json` — Chinese
 
-When adding new user-visible text, update both localization files. Use the
+When adding new user-visible text in `package.json`, update both localization files. Use the
 `%key%` syntax to reference localization strings in `package.json`.
+
+The key in `%key%` is the path to the item. If the item needs to be accessed through
+an array, the position in the array is represented as the field that makes the item unique (
+e.g., `id`). For example, in `package.json`:
+
+```json
+"contributes": {
+  "walkthroughs": [
+    {
+        "id": "ruyi.welcome",
+        "title": "%contributes.walkthroughs.ruyi.welcome.title%",
+        "description": "%contributes.walkthroughs.ruyi.welcome.description%",
+    }
+  ]
+}
+```
+
+The "key" to the "title" above is `contributes.walkthroughs.ruyi.welcome.title`.
 
 ## Testing
 

--- a/CONTRIBUTING.zh.md
+++ b/CONTRIBUTING.zh.md
@@ -347,17 +347,37 @@ which fails on Windows. Now using path.join for cross-platform support.
 
 ## 本地化
 
-本项目支持中英文双语。本地化文件位于 `l10n/` 目录：
+本项目使用 [`vscode-l10n`](https://github.com/microsoft/vscode-l10n) 进行本地化。目前支持中文和英文。
+
+消息文件位于 `l10n/` 目录中：
 
 - `bundle.l10n.json` — 英文源文件
-- `bundle.l10n.zh-cn.json` — 中文翻译
+- `bundle.l10n.zh-cn.json` — 中文翻译文件
 
-`package.json` 中的用户可见字符串通过以下文件本地化：
+要了解如何在 TypeScript 代码中添加新消息，请参阅 [vscode-l10n-dev](https://github.com/microsoft/vscode-l10n/tree/main/l10n-dev)。
+
+`package.json` 中面向用户的字符串通过以下文件进行本地化：
 
 - `package.nls.json` — 英文
 - `package.nls.zh-cn.json` — 中文
 
-新增用户可见文本时，请同时更新中英文两套本地化文件。使用 `%key%` 语法在 `package.json` 中引用本地化字符串。
+在 `package.json` 中添加新的面向用户文本时，请同时更新这两个本地化文件。使用 `%key%` 语法在 `package.json` 中引用本地化字符串。
+
+`%key%` 中的键（key）以该项的路径命名。如果该项需要通过数组访问，则数组中的位置用使该项唯一的字段（例如 `id`）来表示。例如，在 `package.json` 中：
+
+```json
+"contributes": {
+  "walkthroughs": [
+    {
+        "id": "ruyi.welcome",
+        "title": "%contributes.walkthroughs.ruyi.welcome.title%",
+        "description": "%contributes.walkthroughs.ruyi.welcome.description%",
+    }
+  ]
+}
+```
+
+上面 "title" 对应的 "key" 是 `contributes.walkthroughs.ruyi.welcome.title`。
 
 ## 测试
 


### PR DESCRIPTION
更新 `CONTRIBUTING.md` （中文和英文版本）中关于本地化部分的表达，以更好地指引贡献者对 l10n 工具的使用。

加入了指向微软官方 vscode-l10n 相关页面的链接。

加入了本项目中使用的 `package.nls.json` 中 "key" 的命名规范。

## Summary by Sourcery

Clarify localization guidance in both English and Chinese CONTRIBUTING docs, documenting vscode-l10n usage, message file locations, and package.nls.json key naming conventions.

Documentation:
- Update English and Chinese CONTRIBUTING guides to describe vscode-l10n usage and point to official l10n development resources.
- Document the naming convention for localization keys used in package.nls.json with a concrete example.