### PR TITLE
feat: check if a sysroot is contained while creating venv

### DIFF
--- a/src/ruyi/types.ts
+++ b/src/ruyi/types.ts
@@ -13,6 +13,9 @@ export interface RuyiVersionInfo {
       desc?: string
       slug?: string
     }
+    toolchain?: {
+      included_sysroot?: string
+    }
   }
 }
 

--- a/src/venv/sysroot.helper.ts
+++ b/src/venv/sysroot.helper.ts
@@ -7,10 +7,9 @@
  */
 
 import { logger } from '../common/logger'
-import ruyi from '../ruyi'
 
 import { SysrootPkgResult } from './types'
-import { parsePkgs } from './venv.helper'
+import { getToolchainsFromRuyi } from './venv.helper'
 
 /**
  * Fetches all available Ruyi packages that can be used as a sysroot from the ruyi CLI.
@@ -18,15 +17,20 @@ import { parsePkgs } from './venv.helper'
  * @returns Promise resolving to an array of SysrootPkgInfo objects, or an error object on failure
  */
 export async function getSysrootPkgsFromRuyi(): Promise<SysrootPkgResult> {
-  // TODO: Not all `toolchain` packages contains a sysroot, but Ruyi has not provided a way to check
-  // it yet.
-  const result = await ruyi.list({ categoryIs: 'toolchain' })
-
-  if (result.code === 0) {
-    return parsePkgs(result.stdout)
+  try {
+    const toolchains = await getToolchainsFromRuyi()
+    const sysroots = toolchains.filter(toolchain => toolchain.included_sysroot)
+    const sysrootPkgs = sysroots.map(toolchain => (
+      {
+        name: toolchain.name,
+        semver: toolchain.version,
+        remarks: toolchain.remarks,
+      }
+    ))
+    return sysrootPkgs
   }
-  else {
-    const errorMsg = `Failed to get sysroot packages: ${result.stderr}`
+  catch (error) {
+    const errorMsg = `Failed to get sysroot packages: ${error}`
     logger.error(errorMsg)
     return { errorMsg }
   }

--- a/src/venv/types.ts
+++ b/src/venv/types.ts
@@ -34,6 +34,10 @@ export interface Toolchain {
   latest: boolean
   /** Package slug for installation */
   slug: string | null
+  /** Installation status remarks (e.g. ['installed', 'latest']) */
+  remarks: string[]
+  /** Included sysroot of the package */
+  included_sysroot?: string
 }
 
 /**

--- a/src/venv/venv.helper.ts
+++ b/src/venv/venv.helper.ts
@@ -49,6 +49,8 @@ export function parseToolchains(output: string): Toolchain[] {
         installed: remarks.includes('installed'),
         latest: remarks.includes('latest'),
         slug: v.pm?.metadata?.slug || null,
+        remarks,
+        included_sysroot: v.pm?.toolchain?.included_sysroot,
       })
     }
   }


### PR DESCRIPTION
fixed #205

## Summary by Sourcery

Check for toolchains that include a sysroot when resolving sysroot packages for virtual environments.

New Features:
- Expose included sysroot information from Ruyi toolchain metadata and surface it on Toolchain objects used by venv helpers.

Enhancements:
- Update sysroot package retrieval to reuse parsed toolchain data, filtering only toolchains that contain a sysroot and mapping them into sysroot package results.