### PR TITLE
feat: support ruyi 0.51 macos auto-install

### DIFF
--- a/l10n/bundle.l10n.json
+++ b/l10n/bundle.l10n.json
@@ -69,7 +69,7 @@
   "Later": "Later",
   "A new version of Ruyi is available: {0} (current: {1})": "A new version of Ruyi is available: {0} (current: {1})",
   "Update now": "Update now",
-  "Automatic installation is only supported on Linux. Please install Ruyi manually.": "Automatic installation is only supported on Linux. Please install Ruyi manually.",
+  "Automatic installation is only supported on Linux and macOS. Please install Ruyi manually.": "Automatic installation is only supported on Linux and macOS. Please install Ruyi manually.",
   "Open Installation Guide": "Open Installation Guide",
   "Ruyi already installed: {0}": "Ruyi already installed: {0}",
   "Installing Ruyi via {0}...": "Installing Ruyi via {0}...",

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -69,7 +69,7 @@
   "Later": "稍后",
   "A new version of Ruyi is available: {0} (current: {1})": "Ruyi 有新版本可用：{0}（当前版本：{1}）",
   "Update now": "立即更新",
-  "Automatic installation is only supported on Linux. Please install Ruyi manually.": "自动安装仅支持 Linux 系统。请手动安装 Ruyi。",
+  "Automatic installation is only supported on Linux and macOS. Please install Ruyi manually.": "自动安装仅支持 Linux 和 macOS 操作系统。请手动安装 Ruyi。",
   "Open Installation Guide": "打开安装指南",
   "Ruyi already installed: {0}": "Ruyi 已安装：{0}",
   "Installing Ruyi via {0}...": "正在通过 {0} 安装 Ruyi...",

--- a/src/setup/setup.command.ts
+++ b/src/setup/setup.command.ts
@@ -115,9 +115,9 @@ export async function checkRuyiUpdate(currentVersion: string): Promise<void> {
 
 export function registerInstallCommand(ctx: vscode.ExtensionContext): void {
   const disposable = vscode.commands.registerCommand('ruyi.setup.install', async () => {
-    if (process.platform !== 'linux') {
+    if (!['linux', 'darwin'].includes(process.platform)) {
       const choice = await vscode.window.showWarningMessage(
-        vscode.l10n.t('Automatic installation is only supported on Linux. Please install Ruyi manually.'),
+        vscode.l10n.t('Automatic installation is only supported on Linux and macOS. Please install Ruyi manually.'),
         vscode.l10n.t('Open Installation Guide'),
         vscode.l10n.t('Cancel'),
       )


### PR DESCRIPTION
Ruyi 0.51 添加了 macOS 支持，因此现在可以让“自动安装”支持 macOS 了。

由于自动安装始终会安装最新版本的 Ruyi，该 PR 不会对旧版支持造成影响。

## Summary by Sourcery

Extend Ruyi automatic installation support to macOS alongside Linux.

New Features:
- Allow invoking the Ruyi automatic installation command on macOS in addition to Linux.

Enhancements:
- Update localized warning messages to reflect macOS support in both English and Simplified Chinese bundles.