### PR TITLE
fix: auto-install ignores brew-installed pipx on macos

### DIFF
--- a/src/setup/setup.helper.ts
+++ b/src/setup/setup.helper.ts
@@ -2,16 +2,32 @@
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 
+import { logger } from '../common/logger'
+
 const execFileAsync = promisify(execFile)
 
 const PACKAGE_METHODS = {
   pip: {
-    install: ['-m', 'pip', 'install', '--user', '-U', 'ruyi'],
-    update: ['-m', 'pip', 'install', '--user', '-U', 'ruyi'],
+    install: [
+      ['python3', '-m', 'pip', 'install', '--user', '-U', 'ruyi'],
+      ['pip3', 'install', '--user', '-U', 'ruyi'],
+      ['pip', 'install', '--user', '-U', 'ruyi'],
+    ],
+    update: [
+      ['python3', '-m', 'pip', 'install', '--user', '-U', 'ruyi'],
+      ['pip3', 'install', '--user', '-U', 'ruyi'],
+      ['pip', 'install', '--user', '-U', 'ruyi'],
+    ],
   },
   pipx: {
-    install: ['-m', 'pipx', 'install', 'ruyi'],
-    update: ['-m', 'pipx', 'upgrade', 'ruyi'],
+    install: [
+      ['python3', '-m', 'pipx', 'install', 'ruyi'],
+      ['pipx', 'install', 'ruyi'],
+    ],
+    update: [
+      ['python3', '-m', 'pipx', 'upgrade', 'ruyi'],
+      ['pipx', 'upgrade', 'ruyi'],
+    ],
   },
 } as const
 
@@ -24,8 +40,16 @@ async function executeRuyiPackageCommand(
   methodKey: PackageMethodKey,
   operation: PackageOperation,
 ): Promise<void> {
-  const args = PACKAGE_METHODS[methodKey][operation]
-  await execFileAsync('python3', [...args], { timeout: 60_000 })
+  for (const args of PACKAGE_METHODS[methodKey][operation]) {
+    try {
+      await execFileAsync(args[0], [...args.slice(1)], { timeout: 60_000 })
+      return
+    }
+    catch (error) {
+      logger.log(`Not executed ${args.join(' ')}: ${error}, trying next command if available.`)
+    }
+  }
+  throw new Error(`Failed to execute any command for ${methodKey} ${operation}.`)
 }
 
 export function executeRuyiInstall(methodKey: PackageMethodKey): Promise<void> {


### PR DESCRIPTION
当前的自动安装强制调用 python3 -m pip/pipx，但对于类似 macOS 上通过 brew 安装的 pipx，这是无效的。

Ruyi 0.51 已加入了对 macOS 的支持。此外，一些 Linux 系统如果安装了多个渠道的 Python，也可能具有类似的问题。

## Summary by Sourcery

Improve package installation helper to support multiple pip/pipx invocation methods and log failures while falling back to alternatives.

Bug Fixes:
- Ensure auto-install detects and uses brew-installed pipx and various Python/pip executables on macOS instead of failing when a single command is unavailable.

Enhancements:
- Add structured logging around failed package installation commands to aid debugging of installation issues.