### PR TITLE
feat: only show toolchains with quirks required for selected profile

### DIFF
--- a/src/ruyi/types.ts
+++ b/src/ruyi/types.ts
@@ -15,6 +15,7 @@ export interface RuyiVersionInfo {
     }
     toolchain?: {
       included_sysroot?: string
+      quirks?: string[]
     }
   }
 }

--- a/src/venv/create.command.ts
+++ b/src/venv/create.command.ts
@@ -12,6 +12,7 @@ type ToolchainPick = vscode.QuickPickItem & {
   version: string
   latest: boolean
   installed: boolean
+  quirks: string[]
 }
 
 type EmulatorPick = vscode.QuickPickItem & {
@@ -109,9 +110,11 @@ export async function createVenvCommand(service: VenvService): Promise<void> {
 
   // 2. Select Profile
   const allProfiles = await service.getProfiles()
-  const profileItems = Object.entries(allProfiles).map(([label, description]) => ({
-    label,
-    description,
+  const profileItems = allProfiles.map(profile => ({
+    label: profile.displayName,
+    description: profile.neededToolchainQuirks.length > 0
+      ? `(needs quirks: ${profile.neededToolchainQuirks.join(', ')})`
+      : undefined,
   }))
 
   const pickedProfile = await vscode.window.showQuickPick(profileItems, {
@@ -122,6 +125,7 @@ export async function createVenvCommand(service: VenvService): Promise<void> {
     return
   }
   const profile = pickedProfile.label
+  const neededQuirks = allProfiles.find(p => p.displayName === profile)?.neededToolchainQuirks ?? []
 
   // 3. Select Toolchains
   const toolchains = await service.getToolchains()
@@ -137,7 +141,8 @@ export async function createVenvCommand(service: VenvService): Promise<void> {
     version: toolchain.version,
     latest: toolchain.latest,
     installed: toolchain.installed,
-  }))
+    quirks: toolchain.quirks,
+  })).filter(tc => neededQuirks.every(quirk => tc.quirks.includes(quirk)))
 
   const pickedToolchains = await vscode.window.showQuickPick(toolchainItems, {
     placeHolder: vscode.l10n.t('Select one or more toolchains for the new venv'),

--- a/src/venv/index.ts
+++ b/src/venv/index.ts
@@ -57,7 +57,7 @@ export { VenvService } from './venv.service'
 
 // Export Helpers
 export { scanWorkspaceForVenvs as detectVenvs } from './detection.helper'
-export { getProfilesFromRuyi as getProfiles, type ProfilesMap } from './profile.helper'
+export { getProfilesFromRuyi as getProfiles } from './profile.helper'
 export { getToolchainsFromRuyi as getToolchains, type Toolchain } from './venv.helper'
 export { getEmulatorsFromRuyi as getEmulators, type EmulatorInfo } from './emulator.helper'
 

--- a/src/venv/profile.helper.ts
+++ b/src/venv/profile.helper.ts
@@ -10,9 +10,9 @@ import { logger } from '../common/logger'
 import ruyi from '../ruyi'
 import type { RuyiResult } from '../ruyi'
 
-import type { ProfilesMap, RuyiProfile } from './types'
+import type { RuyiProfile } from './types'
 
-export type { ProfilesMap, RuyiProfile }
+export type { RuyiProfile }
 
 /**
  * Parse the JSON Lines output from entity list command into RuyiProfile array
@@ -55,19 +55,11 @@ function parseProfilesOutput(result: RuyiResult): RuyiProfile[] {
  * @param profiles - Array of structured profile objects
  * @returns Dictionary mapping profile display names to descriptions (or undefined)
  */
-export function parseProfiles(profiles: RuyiProfile[]): ProfilesMap {
-  const dict: Record<string, string | undefined> = {}
-
-  for (const profile of profiles) {
-    // Build description only if quirks exist
-    const description = profile.neededToolchainQuirks.length > 0
-      ? `(needs quirks: ${profile.neededToolchainQuirks.join(', ')})`
-      : undefined
-
-    dict[profile.displayName] = description
-  }
-
-  return dict
+export function profileTexts(profile: RuyiProfile): [string, string | undefined] {
+  const description = profile.neededToolchainQuirks.length > 0
+    ? `(needs quirks: ${profile.neededToolchainQuirks.join(', ')})`
+    : undefined
+  return [profile.displayName, description]
 }
 
 /**
@@ -76,11 +68,10 @@ export function parseProfiles(profiles: RuyiProfile[]): ProfilesMap {
  * @returns Promise resolving to a dictionary of profiles
  * @throws Error if the ruyi command fails
  */
-export async function getProfilesFromRuyi(): Promise<ProfilesMap> {
+export async function getProfilesFromRuyi(): Promise<RuyiProfile[]> {
   try {
     const result = await ruyi.listProfiles()
-    const profiles = parseProfilesOutput(result)
-    return parseProfiles(profiles)
+    return parseProfilesOutput(result)
   }
   catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error)

--- a/src/venv/types.ts
+++ b/src/venv/types.ts
@@ -38,6 +38,8 @@ export interface Toolchain {
   remarks: string[]
   /** Included sysroot of the package */
   included_sysroot?: string
+  /** Quirks included in the package */
+  quirks: string[]
 }
 
 /**
@@ -67,13 +69,6 @@ export interface RuyiProfile {
   /** Common toolchain flags for this profile */
   toolchainCommonFlagsStr: string
 }
-
-/**
- * Map of profile display names to their optional descriptions.
- * Key is the profile display name for QuickPick label.
- * Value is the description (e.g., quirks info) or undefined if none.
- */
-export type ProfilesMap = Record<string, string | undefined>
 
 /**
  * Result type for emulator fetching that can be either success or error.

--- a/src/venv/venv.helper.ts
+++ b/src/venv/venv.helper.ts
@@ -65,6 +65,7 @@ export function parseToolchains(output: string): Toolchain[] {
         slug: v.pm?.metadata?.slug || null,
         remarks,
         included_sysroot: v.pm?.toolchain?.included_sysroot,
+        quirks: v.pm?.toolchain?.quirks || [],
       })
     }
   }

--- a/src/venv/venv.service.ts
+++ b/src/venv/venv.service.ts
@@ -22,8 +22,8 @@ import type {
   VenvInfo,
   Toolchain,
   EmulatorResult,
-  ProfilesMap,
   SysrootPkgResult,
+  RuyiProfile,
 } from './types'
 import { getToolchainsFromRuyi } from './venv.helper'
 
@@ -94,7 +94,7 @@ export class VenvService implements vscode.Disposable {
   /**
    * Gets available Ruyi profiles.
    */
-  public async getProfiles(): Promise<ProfilesMap> {
+  public async getProfiles(): Promise<RuyiProfile[]> {
     return getProfilesFromRuyi()
   }
 


### PR DESCRIPTION
目前，创建虚拟环境时，如果选择了一个要求特定 quirks 的 profile，仍然可以选择没有这些 quirk 的 toolchain 包，这会在多步操作以后报错。

这个 PR 将会过滤 toolchain 包，确保用户只能选择合法的工具栏，以防止用户错误操作，“提前”解决该问题。

## Summary by Sourcery

Restrict venv toolchain selection to only those compatible with the selected profile's required quirks and propagate quirks metadata through profiles and toolchains.

New Features:
- Filter selectable toolchains in the venv creation flow to only those whose quirks satisfy the selected profile's required quirks.
- Expose toolchain quirks information from the Ruyi metadata into the extension's Toolchain model.

Enhancements:
- Simplify profile handling by returning full RuyiProfile objects instead of a map and generating display texts at the call site.